### PR TITLE
Potion replacements

### DIFF
--- a/utility_code/lib_py3/item_replacement_substitutions.py
+++ b/utility_code/lib_py3/item_replacement_substitutions.py
@@ -440,8 +440,11 @@ class SubtituteItems(SubstitutionRule):
                 ["minecraft:leather_chestplate", "Dichen Gambison", "minecraft:leather_chestplate", "Dichen Gambeson"],
                 ["minecraft:gray_dye", "Archite Ring", "minecraft:gray_dye", "Archos Ring"],
                 ["minecraft:firework_star", "Hyperchromatic Archite Ring", "minecraft:firework_star", "Hyperchromatic Archos Ring"],
-
-
+                ["minecraft:golden_apple", None, "minecraft:golden_apple", "Kingfruit"]
+                ["minecraft:enchanted_golden_apple", None, "minecraft:enchanted_golden_apple", "Soulfruit"],
+                # ["minecraft:potion", None, "minecraft:potion", "Bygone Brew"], //TODO: Fix Water bottles and uncomment this line
+                ["minecraft:splash_potion", None, "minecraft:potion", "Bygone Brew"],
+                ["minecraft:lingering_potion", None, "minecraft:potion", "Bygone Brew"],
         ]:
 
             old_id, old_name, new_id, new_name = substitution


### PR DESCRIPTION
Left out standard unnamed potions until water bottle fix is made. This should ONLY be updating UNNAMED golden apples and splash/lingering potions. Any named potions that got missed will be updated by hand via loot tables. 