### PR TITLE
Bump CI dependencies, Swap images in docker

### DIFF
--- a/.github/workflows/plugin_build_common.yml
+++ b/.github/workflows/plugin_build_common.yml
@@ -16,7 +16,7 @@ jobs:
         java-version: 17
         check-latest: true
     # Git config, not sure why this is needed?
-    - name: Apply global CI config
+    - name: Apply global Git config
       run: |
           git config --global user.name "Monumenta CI"
           git config --global user.email "Monumenta.CI@NotARealEmail.com"

--- a/.github/workflows/plugin_build_common.yml
+++ b/.github/workflows/plugin_build_common.yml
@@ -4,23 +4,25 @@ on: [workflow_call]
 # Jobs
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v2
+    - name: Checkout Repository
+      uses: actions/checkout@v4
     # Set up JDK, we might want to bump this to Java 21
     - name: Set up JDK 17
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v4
       with:
-        distribution: zulu # See 'Supported distributions' for available options
-        java-version: "17"
+        distribution: zulu
+        java-version: 17
+        check-latest: true
     # Git config, not sure why this is needed?
-    - name: git config
+    - name: Apply global CI config
       run: |
           git config --global user.name "Monumenta CI"
           git config --global user.email "Monumenta.CI@NotARealEmail.com"
     # Cache dependencies so we don't have to download them every run
     - name: Cache maven dependencies
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       env:
         cache-name: cache-maven-dependencies
       with:

--- a/.github/workflows/plugin_pr_common.yml
+++ b/.github/workflows/plugin_pr_common.yml
@@ -5,28 +5,30 @@ on: [workflow_call]
 jobs:
   reviewdog:
     name: reviewdog
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v2
+    - name: Checkout Repository
+      uses: actions/checkout@v4
     # Set up JDK, we might want to bump this to Java 21
     - name: Set up JDK 17
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v4
       with:
-        distribution: zulu # See 'Supported distributions' for available options
-        java-version: "17"
+        distribution: zulu
+        java-version: 17
+        check-latest: true
     # Reviewdog
     - name: Setup reviewdog
       uses: reviewdog/action-setup@v1
       with:
         reviewdog_version: latest
     # Git config, not sure why this is needed?
-    - name: git config
+    - name: Apply global CI config
       run: |
         git config --global user.name "Monumenta CI"
         git config --global user.email "Monumenta.CI@NotARealEmail.com"
     # Cache dependencies so we don't have to download them every run
     - name: Cache maven dependencies
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       env:
         cache-name: cache-maven-dependencies
       with:

--- a/.github/workflows/plugin_pr_common.yml
+++ b/.github/workflows/plugin_pr_common.yml
@@ -4,7 +4,6 @@ on: [workflow_call]
 # Jobs
 jobs:
   reviewdog:
-    name: reviewdog
     runs-on: ubuntu-22.04
     steps:
     - name: Checkout Repository
@@ -22,7 +21,7 @@ jobs:
       with:
         reviewdog_version: latest
     # Git config, not sure why this is needed?
-    - name: Apply global CI config
+    - name: Apply global Git config
       run: |
         git config --global user.name "Monumenta CI"
         git config --global user.email "Monumenta.CI@NotARealEmail.com"

--- a/.github/workflows/plugin_publish_common.yml
+++ b/.github/workflows/plugin_publish_common.yml
@@ -8,23 +8,25 @@ on:
 # Jobs
 jobs:
   publish:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v2
+    - name: Checkout Repository
+      uses: actions/checkout@v4
     # Set up JDK, we might want to bump this to Java 21
     - name: Set up JDK 17
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v4
       with:
-        distribution: zulu # See 'Supported distributions' for available options
-        java-version: "17"
+        distribution: zulu
+        java-version: 17
+        check-latest: true
     # Git config, not sure why this is needed?
-    - name: git config
+    - name: Apply global CI config
       run: |
           git config --global user.name "Monumenta CI"
           git config --global user.email "Monumenta.CI@NotARealEmail.com"
     # Cache dependencies so we don't have to download them every run
     - name: Cache maven dependencies
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       env:
         cache-name: cache-maven-dependencies
       with:

--- a/.github/workflows/plugin_publish_common.yml
+++ b/.github/workflows/plugin_publish_common.yml
@@ -20,7 +20,7 @@ jobs:
         java-version: 17
         check-latest: true
     # Git config, not sure why this is needed?
-    - name: Apply global CI config
+    - name: Apply global Git config
       run: |
           git config --global user.name "Monumenta CI"
           git config --global user.email "Monumenta.CI@NotARealEmail.com"

--- a/docker/automation-bot.Dockerfile
+++ b/docker/automation-bot.Dockerfile
@@ -11,8 +11,6 @@ RUN cd /tmp && \
 	make -j 4 && \
 	make install
 
-FROM ubuntu:22.04
-
 RUN apt-get update && \
 	apt-get install -y software-properties-common && \
 	add-apt-repository -y ppa:pypy/ppa && \

--- a/docker/java-shard-17.Dockerfile
+++ b/docker/java-shard-17.Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:17-jdk-buster
+FROM eclipse-temurin:17
 
 RUN apt-get update && \
 	apt-get install -y --no-install-recommends python3 python3-yaml python3-pip python3-setuptools python3-numpy && \


### PR DESCRIPTION
1. Freezes the linux image to Ubuntu 22.04 to avoid possible conflicts with older software,
2. Updates checkout, setup-java and cache to v4,
3. Fixes an visual issue where the checkout name is not properly displayed,
4. Removes duplicate `FROM` statement in automation-bot docker file,
5. Swaps the JDK image with Temurin for java-shard-17 docker file,
6. Removes bad `name` statement from plugin_pr_common workflow.