### PR TITLE
"env" -> "secrets" in plugin_pr_common

### DIFF
--- a/.github/workflows/plugin_pr_common.yml
+++ b/.github/workflows/plugin_pr_common.yml
@@ -44,7 +44,7 @@ jobs:
           ${{ runner.os }}-
     # Reviewdog stuff...
     - name: Build and report style/pmd/warnings
-      env:
+      secrets:
         REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         shopt -s nullglob


### PR DESCRIPTION
The former command is illegal to use in `workflow_call` scenarios as otherwise it would collide with the system reserved name.