### PR TITLE
Improvements to the rust heaptool for automated heap dump analysis

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -652,12 +652,14 @@ dependencies = [
  "hematite-nbt",
  "itertools 0.14.0",
  "lazy_static",
+ "libc",
  "log",
  "memmap2",
  "phf",
  "rayon",
  "redis",
  "regex",
+ "rustc-hash",
  "serde",
  "serde_json",
  "serde_norway",
@@ -891,6 +893,12 @@ name = "regex-syntax"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustversion"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -28,3 +28,5 @@ phf = { version = "0.13.1", features = ["macros"] }
 memmap2 = "0.9.9"
 smallvec = { version = "1.15.1", features = ["union"] }
 itertools = "0.14.0"
+rustc-hash = "2"
+libc = "0.2"

--- a/rust/src/bin/heaptool.rs
+++ b/rust/src/bin/heaptool.rs
@@ -16,6 +16,11 @@ struct Cli {
     #[arg(long, default_value_t = 1)]
     min_leaked: usize,
 
+    /// Minimum number of leaked instances for a pattern group to be included in output. Groups
+    /// below this threshold are still counted in the header but not printed.
+    #[arg(long, default_value_t = 1)]
+    min_pattern_leaked: usize,
+
     /// Disable inner class name normalization in pattern signatures. By default, inner class
     /// suffixes are stripped (e.g. HashMap$Node and HashMap$TreeNode both become HashMap;
     /// BossAbilityGroup$1 and BossAbilityGroup$2 both become BossAbilityGroup) so that
@@ -33,7 +38,7 @@ struct Cli {
 fn main() -> Result<()> {
     let args = Cli::parse();
     let contents = unsafe { Mmap::map(&File::open(args.file)?)? };
-    let leaks_found = read_prof(&contents, args.min_leaked, !args.no_normalize_inner_classes, args.show_ids)?;
+    let leaks_found = read_prof(&contents, args.min_leaked, args.min_pattern_leaked, !args.no_normalize_inner_classes, args.show_ids)?;
     if leaks_found {
         std::process::exit(1);
     }

--- a/rust/src/bin/heaptool.rs
+++ b/rust/src/bin/heaptool.rs
@@ -15,12 +15,25 @@ struct Cli {
     /// dump was captured.
     #[arg(long, default_value_t = 1)]
     min_leaked: usize,
+
+    /// Disable inner class name normalization in pattern signatures. By default, inner class
+    /// suffixes are stripped (e.g. HashMap$Node and HashMap$TreeNode both become HashMap;
+    /// BossAbilityGroup$1 and BossAbilityGroup$2 both become BossAbilityGroup) so that
+    /// structurally equivalent patterns are grouped together.
+    #[arg(long)]
+    no_normalize_inner_classes: bool,
+
+    /// Show object IDs (hex addresses) next to each entry in pattern output. IDs are from one
+    /// arbitrary example instance and change between runs, so they are hidden by default to keep
+    /// output diff-friendly.
+    #[arg(long)]
+    show_ids: bool,
 }
 
 fn main() -> Result<()> {
     let args = Cli::parse();
     let contents = unsafe { Mmap::map(&File::open(args.file)?)? };
-    let leaks_found = read_prof(&contents, args.min_leaked)?;
+    let leaks_found = read_prof(&contents, args.min_leaked, !args.no_normalize_inner_classes, args.show_ids)?;
     if leaks_found {
         std::process::exit(1);
     }

--- a/rust/src/bin/heaptool.rs
+++ b/rust/src/bin/heaptool.rs
@@ -9,11 +9,20 @@ use monumenta::hprof::read_prof;
 struct Cli {
     #[arg()]
     file: String,
+
+    /// Minimum number of leaked instances of a given class to report and trigger a non-zero exit
+    /// code. Use this to avoid false positives from objects transiently in-flight when the heap
+    /// dump was captured.
+    #[arg(long, default_value_t = 1)]
+    min_leaked: usize,
 }
 
 fn main() -> Result<()> {
     let args = Cli::parse();
     let contents = unsafe { Mmap::map(&File::open(args.file)?)? };
-    read_prof(&contents)?;
+    let leaks_found = read_prof(&contents, args.min_leaked)?;
+    if leaks_found {
+        std::process::exit(1);
+    }
     Ok(())
 }

--- a/rust/src/bin/heaptool.rs
+++ b/rust/src/bin/heaptool.rs
@@ -33,12 +33,18 @@ struct Cli {
     /// output diff-friendly.
     #[arg(long)]
     show_ids: bool,
+
+    /// Emit results as a JSON array to stdout. Each element has an instance_count and a chain
+    /// array of compact display strings matching the normal text output (runs collapsed, field
+    /// annotations included). Progress and summary messages are still written to stderr.
+    #[arg(long)]
+    json: bool,
 }
 
 fn main() -> Result<()> {
     let args = Cli::parse();
     let contents = unsafe { Mmap::map(&File::open(args.file)?)? };
-    let leaks_found = read_prof(&contents, args.min_leaked, args.min_pattern_leaked, !args.no_normalize_inner_classes, args.show_ids)?;
+    let leaks_found = read_prof(&contents, args.min_leaked, args.min_pattern_leaked, !args.no_normalize_inner_classes, args.show_ids, args.json)?;
     if leaks_found {
         std::process::exit(1);
     }

--- a/rust/src/hprof/graph.rs
+++ b/rust/src/hprof/graph.rs
@@ -1,7 +1,4 @@
-use std::{
-    collections::{HashMap, HashSet},
-    rc::Rc,
-};
+use std::collections::{HashMap, HashSet, VecDeque};
 
 use crate::hprof::id::Id;
 
@@ -16,30 +13,6 @@ pub fn clean_graph<T: Id + Ord + Copy>(edges: &mut Vec<(T, T)>) {
     edges.sort_unstable();
     edges.dedup();
     edges.shrink_to_fit();
-}
-
-pub struct ConsNode<T>(T, Option<ConsList<T>>);
-pub type ConsList<T> = Rc<ConsNode<T>>;
-
-fn cons<T>(val: T) -> ConsList<T> {
-    Rc::new(ConsNode(val, None))
-}
-
-fn cons_list<T>(val: T, next: ConsList<T>) -> ConsList<T> {
-    Rc::new(ConsNode(val, Some(next)))
-}
-
-pub fn to_vec<T: Clone>(list: &ConsList<T>) -> Vec<T> {
-    let mut out = Vec::new();
-    let mut current: Option<&ConsList<T>> = Some(list);
-
-    while let Some(node_rc) = current {
-        let ConsNode(ref head, ref tail) = **node_rc;
-        out.push(head.clone());
-        current = tail.as_ref();
-    }
-
-    out
 }
 
 pub fn is_reachable<T: Id, U: Fn(T) -> bool>(graph: &[(T, T)], root_pred: U, start_nodes: &[T]) -> Vec<bool> {
@@ -96,68 +69,40 @@ pub fn is_reachable<T: Id, U: Fn(T) -> bool>(graph: &[(T, T)], root_pred: U, sta
     res
 }
 
-pub fn find_paths<T: Id, U: Fn(T) -> bool>(
-    graph: &[(T, T)],
-    root_pred: U,
-    start_nodes: &[T],
-    max_paths: usize,
-) -> Vec<Vec<ConsList<T>>> {
-    let mut reachable: IntMap<T, Vec<ConsList<T>>> = IntMap::default();
-    let mut temp_vis: IntSet<T> = IntSet::default();
+/// BFS shortest path from `start` through back-reference edges to any node matching `root_pred`.
+/// Returns the path as [start, ..., root], or an empty Vec if no path exists.
+pub fn find_shortest_path<T: Id, U: Fn(T) -> bool>(graph: &[(T, T)], root_pred: U, start: T) -> Vec<T> {
+    let mut came_from: IntMap<T, Option<T>> = IntMap::default();
+    let mut queue: VecDeque<T> = VecDeque::new();
 
-    fn dfs<T: Id, U: Fn(T) -> bool>(
-        u: T,
-        graph: &[(T, T)],
-        root_pred: &U,
-        reachable: &mut IntMap<T, Vec<ConsList<T>>>,
-        temp_vis: &mut IntSet<T>,
-        max_paths: usize,
-    ) -> Vec<ConsList<T>> {
-        if let Some(x) = reachable.get(&u) {
-            return x.clone();
-        }
+    came_from.insert(start, None);
+    queue.push_back(start);
 
+    while let Some(u) = queue.pop_front() {
         if root_pred(u) {
-            reachable.insert(u, vec![cons(u)]);
-            return vec![cons(u)];
-        }
-
-        if temp_vis.contains(&u) {
-            return vec![];
-        }
-
-        temp_vis.insert(u);
-
-        let mut found = vec![];
-
-        let mut idx = graph.partition_point(|&(src, _)| src < u);
-
-        while idx < graph.len() && graph[idx].0 == u {
-            for node in dfs(graph[idx].1, graph, root_pred, reachable, temp_vis, max_paths) {
-                found.push(cons_list(u, node));
-                if found.len() >= max_paths {
-                    break;
+            let mut path = Vec::new();
+            let mut cur = u;
+            loop {
+                path.push(cur);
+                match came_from[&cur] {
+                    None => break,
+                    Some(prev) => cur = prev,
                 }
             }
-
-            if found.len() >= max_paths {
-                break;
-            }
-
-            idx += 1;
+            path.reverse();
+            return path;
         }
 
-        temp_vis.remove(&u);
-
-        reachable.insert(u, found.clone());
-
-        found
+        let mut idx = graph.partition_point(|&(src, _)| src < u);
+        while idx < graph.len() && graph[idx].0 == u {
+            let v = graph[idx].1;
+            if !came_from.contains_key(&v) {
+                came_from.insert(v, Some(u));
+                queue.push_back(v);
+            }
+            idx += 1;
+        }
     }
 
-    let mut res = Vec::new();
-    for &s in start_nodes {
-        res.push(dfs(s, graph, &root_pred, &mut reachable, &mut temp_vis, max_paths));
-    }
-
-    res
+    vec![]
 }

--- a/rust/src/hprof/graph.rs
+++ b/rust/src/hprof/graph.rs
@@ -1,9 +1,11 @@
-use std::collections::{HashMap, HashSet, VecDeque};
+use std::collections::VecDeque;
+
+use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::hprof::id::Id;
 
-pub type IntMap<K, V> = HashMap<K, V>;
-pub type IntSet<K> = HashSet<K>;
+pub type IntMap<K, V> = FxHashMap<K, V>;
+pub type IntSet<K> = FxHashSet<K>;
 
 pub fn clean_graph<T: Id + Ord + Copy>(edges: &mut Vec<(T, T)>) {
     if edges.is_empty() {

--- a/rust/src/hprof/id.rs
+++ b/rust/src/hprof/id.rs
@@ -1,5 +1,5 @@
 use std::{
-    fmt::{Debug, Display, LowerHex},
+    fmt::{self, Debug, Display, LowerHex},
     hash::Hash,
     io::Error,
 };
@@ -27,5 +27,36 @@ impl Id for u64 {
         let res = buf.read_u64::<BigEndian>()?;
         debug_assert!(res & 0b111 == 0);
         Ok(res >> 3)
+    }
+}
+
+/// Reads 8-byte (uncompressed OOP) IDs from the HPROF file but stores them
+/// as u32 after the standard >> 3 alignment shift.  Valid for heaps ≤ 32 GB,
+/// where the shifted value never exceeds u32::MAX.  This halves edge-vector
+/// memory compared to storing the same IDs as u64.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Debug, Default)]
+pub struct OopId(pub u32);
+
+impl Display for OopId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        Display::fmt(&self.0, f)
+    }
+}
+
+impl LowerHex for OopId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        LowerHex::fmt(&self.0, f)
+    }
+}
+
+impl Id for OopId {
+    const NULL: Self = OopId(0);
+
+    fn read_from(buf: &mut &[u8]) -> Result<Self, Error> {
+        let raw = buf.read_u64::<BigEndian>()?;
+        debug_assert!(raw & 0b111 == 0, "unaligned OOP: {raw:#x}");
+        let shifted = raw >> 3;
+        debug_assert!(shifted <= u32::MAX as u64, "OOP exceeds u32 range (heap > 32 GB?): {shifted}");
+        Ok(OopId(shifted as u32))
     }
 }

--- a/rust/src/hprof/id.rs
+++ b/rust/src/hprof/id.rs
@@ -8,12 +8,15 @@ use byteorder::{BigEndian, ReadBytesExt};
 
 pub trait Id: Sized + Hash + Copy + Eq + Display + LowerHex + Debug + Ord + Default {
     const NULL: Self;
+    /// Bytes occupied by one ID in the HPROF file (may differ from in-memory size).
+    const FILE_SIZE: usize;
 
     fn read_from(buf: &mut &[u8]) -> Result<Self, Error>;
 }
 
 impl Id for u32 {
     const NULL: Self = 0;
+    const FILE_SIZE: usize = 4;
 
     fn read_from(buf: &mut &[u8]) -> Result<Self, Error> {
         buf.read_u32::<BigEndian>()
@@ -22,6 +25,7 @@ impl Id for u32 {
 
 impl Id for u64 {
     const NULL: Self = 0;
+    const FILE_SIZE: usize = 8;
 
     fn read_from(buf: &mut &[u8]) -> Result<Self, Error> {
         let res = buf.read_u64::<BigEndian>()?;
@@ -51,6 +55,7 @@ impl LowerHex for OopId {
 
 impl Id for OopId {
     const NULL: Self = OopId(0);
+    const FILE_SIZE: usize = 8;
 
     fn read_from(buf: &mut &[u8]) -> Result<Self, Error> {
         let raw = buf.read_u64::<BigEndian>()?;

--- a/rust/src/hprof/mod.rs
+++ b/rust/src/hprof/mod.rs
@@ -685,44 +685,43 @@ fn do_read_prof<'a, T: Id>(file: &'a [u8], min_leaked: usize) -> Result<bool> {
 
     clean_graph(&mut edges);
 
-    let class_types: [(&'static str, &[T]); 3] = [
-        ("WorldServer", &world_server_instances),
-        ("EntityPlayer", &entity_player_instances),
-        ("CraftPlayer", &craft_player_instances),
-    ];
+    // Combine all leak target classes into one pool for unified analysis.
+    let all_leak_target_instances: Vec<T> = world_server_instances
+        .iter()
+        .chain(entity_player_instances.iter())
+        .chain(craft_player_instances.iter())
+        .copied()
+        .collect();
 
-    let mut all_candidates: Vec<Vec<T>> = Vec::new();
-    let mut all_paths: Vec<Vec<Vec<T>>> = Vec::new();
+    // Fast membership test used during path trimming below.
+    let all_leak_target_set: IntSet<T> = all_leak_target_instances.iter().copied().collect();
 
-    for (label, instances) in &class_types {
-        eprintln!("finding paths to root for {label}");
-        eprintln!("found {} instances", instances.len());
+    eprintln!("finding paths to root");
+    eprintln!("found {} total leak target instances", all_leak_target_instances.len());
 
-        let globally_reachable = is_reachable(&edges, |f| gc_roots.contains_key(&f), instances);
-        let non_leaked_instances =
-            is_reachable(&edges, |f| non_leak_root_sources.contains(&f), instances);
+    let globally_reachable =
+        is_reachable(&edges, |f| gc_roots.contains_key(&f), &all_leak_target_instances);
+    let non_leaked_instances =
+        is_reachable(&edges, |f| non_leak_root_sources.contains(&f), &all_leak_target_instances);
 
-        let mut candidates = Vec::new();
-        for (inst, global, non_leak) in
-            izip!(instances.iter(), globally_reachable.iter(), non_leaked_instances.iter())
-        {
-            if !*global || *non_leak {
-                continue;
-            }
+    let mut candidates: Vec<T> = Vec::new();
+    for (inst, global, non_leak) in izip!(
+        all_leak_target_instances.iter(),
+        globally_reachable.iter(),
+        non_leaked_instances.iter()
+    ) {
+        if *global && !*non_leak {
             candidates.push(*inst);
         }
-
-        eprintln!("finding leaked {label} paths-to-root");
-        eprintln!("found {} likely leak candidates", candidates.len());
-
-        let paths: Vec<Vec<T>> = candidates
-            .iter()
-            .map(|&c| find_shortest_path(&edges, |f| leak_root_sources.contains(&f), c))
-            .collect();
-
-        all_candidates.push(candidates);
-        all_paths.push(paths);
     }
+
+    eprintln!("finding leaked instance paths-to-root");
+    eprintln!("found {} likely leak candidates", candidates.len());
+
+    let candidate_paths: Vec<Vec<T>> = candidates
+        .iter()
+        .map(|&c| find_shortest_path(&edges, |f| leak_root_sources.contains(&f), c))
+        .collect();
 
     eprintln!("re-gathering instance data");
 
@@ -730,8 +729,8 @@ fn do_read_prof<'a, T: Id>(file: &'a [u8], min_leaked: usize) -> Result<bool> {
 
     let mut relevant_inst: IntSet<T> = IntSet::default();
     let mut inst_data: IntMap<T, HeapDumpEntry<'a, T>> = IntMap::default();
-    relevant_inst.extend(all_paths.iter().flatten().flatten().copied());
-    relevant_inst.extend(all_candidates.iter().flatten().copied());
+    relevant_inst.extend(candidate_paths.iter().flatten().copied());
+    relevant_inst.extend(candidates.iter().copied());
 
     let mut on_data = |id: T, data: HeapDumpEntry<'a, T>| {
         if relevant_inst.contains(&id) {
@@ -754,171 +753,172 @@ fn do_read_prof<'a, T: Id>(file: &'a [u8], min_leaked: usize) -> Result<bool> {
         },
     )?;
 
-    let mut any_exceeded = false;
+    if candidates.len() < min_leaked {
+        return Ok(false);
+    }
 
-    for (type_info, (candidates, candidate_paths)) in
-        class_types.iter().zip(all_candidates.iter().zip(all_paths.iter()))
-    {
-        let label = type_info.0;
+    // Group paths by class-name signature, deduplicating across all candidate types.
+    // Each path is trimmed to start at the last (nearest-to-scheduler) leak target
+    // in the path: a WorldServer leaked only because a CraftPlayer is leaked folds
+    // into the CraftPlayer's pattern rather than creating a redundant WorldServer entry.
+    let mut pattern_order: Vec<Vec<String>> = Vec::new();
+    let mut pattern_terminals: IntMap<Vec<String>, IntSet<T>> = IntMap::default();
+    let mut pattern_example: IntMap<Vec<String>, Vec<(T, String)>> = IntMap::default();
 
-        if candidates.len() < min_leaked {
-            continue;
-        }
-        any_exceeded = true;
-
-        // Group shortest paths by class-name signature to deduplicate across all candidates.
-        // Many candidates may be held alive by the same code pattern (same class chain),
-        // differing only in which specific instances are involved.
-        let mut pattern_order: Vec<Vec<String>> = Vec::new();
-        let mut pattern_candidates: IntMap<Vec<String>, IntSet<T>> = IntMap::default();
-        let mut pattern_example: IntMap<Vec<String>, Vec<(T, String)>> = IntMap::default();
-
-        for (path, &candidate) in izip!(candidate_paths.iter(), candidates.iter()) {
-            if path.is_empty() {
-                let sig = vec!["<no path found>".to_string()];
-                let is_new = !pattern_candidates.contains_key(&sig);
-                pattern_candidates.entry(sig.clone()).or_default().insert(candidate);
-                if is_new {
-                    pattern_order.push(sig.clone());
-                    pattern_example.insert(sig, vec![]);
-                }
-                continue;
-            }
-
-            // Resolve class names for every element in the path. Field annotations
-            // are collected separately so they don't affect signature matching.
-            let mut raw: Vec<(T, String)> = Vec::new();
-            let mut field_annotations: Vec<Option<String>> = Vec::new();
-            for (i, ele) in path.iter().enumerate() {
-                let name: String = match inst_data.get(ele) {
-                    Some(HeapDumpEntry::InstanceDump(inst)) => {
-                        let class = classes.get(&inst.class_id).unwrap();
-                        let class_name_id = class_names.get(&class.id).unwrap();
-                        let dict = str_dict.borrow();
-                        let class_name = dict.get(class_name_id).unwrap();
-                        str::from_utf8(class_name)?.to_string()
-                    }
-                    Some(HeapDumpEntry::ObjArrayDump(inst)) => {
-                        let class = classes.get(&inst.class_id).unwrap();
-                        let class_name_id = class_names.get(&class.id).unwrap();
-                        let dict = str_dict.borrow();
-                        let class_name = dict.get(class_name_id).unwrap();
-                        format!("{}[]", str::from_utf8(class_name)?)
-                    }
-                    None => {
-                        let class = classes.get(ele).unwrap();
-                        let class_name_id = class_names.get(&class.id).unwrap();
-                        let dict = str_dict.borrow();
-                        let class_name = dict.get(class_name_id).unwrap();
-                        format!("Class<{}>", str::from_utf8(class_name)?)
-                    }
-                    _ => unreachable!(),
-                };
-
-                // For element i > 0, look up which field of path[i] holds path[i-1].
-                let annotation = if i > 0 {
-                    let child = path[i - 1];
-                    edge_field_names.get(&(child, *ele)).map(|&field_id| {
-                        let dict = str_dict.borrow();
-                        dict.get(&field_id)
-                            .and_then(|b| str::from_utf8(b).ok())
-                            .unwrap_or("?")
-                            .to_string()
-                    })
-                } else {
-                    None
-                };
-
-                raw.push((*ele, name));
-                field_annotations.push(annotation);
-            }
-
-            // Signature: collapse consecutive same-class runs to one entry so paths
-            // that differ only in how many HashMap$Node / TreeNode hops the BFS
-            // traversed (varies by hash-bucket depth) map to the same pattern.
-            let mut sig: Vec<String> = Vec::new();
-            for (_, name) in &raw {
-                if sig.last().map_or(true, |last| last != name) {
-                    sig.push(name.clone());
-                }
-            }
-
-            // Display path: same collapsing with run counts, plus field annotations
-            // from the first element of each run.
-            let mut full_path: Vec<(T, String)> = Vec::new();
-            let mut i = 0;
-            while i < raw.len() {
-                let (ele, ref name) = raw[i];
-                let annotation = &field_annotations[i];
-                let mut run = 1;
-                while i + run < raw.len() && raw[i + run].1 == *name {
-                    run += 1;
-                }
-                let base = if run > 1 { format!("{name} (×{run})") } else { name.clone() };
-                let display = if let Some(field) = annotation {
-                    format!("{base}  (.{field})")
-                } else {
-                    base
-                };
-                full_path.push((ele, display));
-                i += run;
-            }
-
-            let is_new = !pattern_candidates.contains_key(&sig);
-            pattern_candidates.entry(sig.clone()).or_default().insert(candidate);
+    for (path, &candidate) in izip!(candidate_paths.iter(), candidates.iter()) {
+        if path.is_empty() {
+            let sig = vec!["<no path found>".to_string()];
+            let is_new = !pattern_terminals.contains_key(&sig);
+            pattern_terminals.entry(sig.clone()).or_default().insert(candidate);
             if is_new {
                 pattern_order.push(sig.clone());
-                pattern_example.insert(sig, full_path);
+                pattern_example.insert(sig, vec![]);
+            }
+            continue;
+        }
+
+        // Trim the path to start at the last leak target class encountered walking
+        // from the candidate toward the scheduler root. This collapses e.g.
+        // [WorldServer, EntityPlayer, CraftPlayer, HashMap, ..., CraftScheduler]
+        // into [CraftPlayer, HashMap, ..., CraftScheduler], attributing the leak
+        // to the innermost retained object rather than its transitive dependents.
+        let trimmed_start = path
+            .iter()
+            .rposition(|id| all_leak_target_set.contains(id))
+            .unwrap_or(0);
+        let trimmed = &path[trimmed_start..];
+        let terminal = trimmed[0];
+
+        // Resolve class names. Field annotations are collected separately so they
+        // don't affect signature matching.
+        let mut raw: Vec<(T, String)> = Vec::new();
+        let mut field_annotations: Vec<Option<String>> = Vec::new();
+        for (i, ele) in trimmed.iter().enumerate() {
+            let name: String = match inst_data.get(ele) {
+                Some(HeapDumpEntry::InstanceDump(inst)) => {
+                    let class = classes.get(&inst.class_id).unwrap();
+                    let class_name_id = class_names.get(&class.id).unwrap();
+                    let dict = str_dict.borrow();
+                    let class_name = dict.get(class_name_id).unwrap();
+                    str::from_utf8(class_name)?.to_string()
+                }
+                Some(HeapDumpEntry::ObjArrayDump(inst)) => {
+                    let class = classes.get(&inst.class_id).unwrap();
+                    let class_name_id = class_names.get(&class.id).unwrap();
+                    let dict = str_dict.borrow();
+                    let class_name = dict.get(class_name_id).unwrap();
+                    format!("{}[]", str::from_utf8(class_name)?)
+                }
+                None => {
+                    let class = classes.get(ele).unwrap();
+                    let class_name_id = class_names.get(&class.id).unwrap();
+                    let dict = str_dict.borrow();
+                    let class_name = dict.get(class_name_id).unwrap();
+                    format!("Class<{}>", str::from_utf8(class_name)?)
+                }
+                _ => unreachable!(),
+            };
+
+            // Look up which field of trimmed[i] holds trimmed[i-1].
+            let annotation = if i > 0 {
+                let child = trimmed[i - 1];
+                edge_field_names.get(&(child, *ele)).map(|&field_id| {
+                    let dict = str_dict.borrow();
+                    dict.get(&field_id)
+                        .and_then(|b| str::from_utf8(b).ok())
+                        .unwrap_or("?")
+                        .to_string()
+                })
+            } else {
+                None
+            };
+
+            raw.push((*ele, name));
+            field_annotations.push(annotation);
+        }
+
+        // Signature: collapse consecutive same-class runs so paths differing only
+        // in HashMap$Node / TreeNode depth map to the same pattern.
+        let mut sig: Vec<String> = Vec::new();
+        for (_, name) in &raw {
+            if sig.last().map_or(true, |last| last != name) {
+                sig.push(name.clone());
             }
         }
 
-        // Most-common patterns first.
-        pattern_order.sort_by(|a, b| pattern_candidates[b].len().cmp(&pattern_candidates[a].len()));
-
-        println!(
-            "=== {} leaked {} instance{}, {} unique retention pattern{} ===\n",
-            candidates.len(),
-            label,
-            if candidates.len() == 1 { "" } else { "s" },
-            pattern_order.len(),
-            if pattern_order.len() == 1 { "" } else { "s" }
-        );
-
-        for (i, sig) in pattern_order.iter().enumerate() {
-            let matching = &pattern_candidates[sig];
-            let example_path = &pattern_example[sig];
-
-            let total_bytes: u64 = matching
-                .iter()
-                .filter_map(|c| {
-                    if let Some(HeapDumpEntry::InstanceDump(inst)) = inst_data.get(c) {
-                        classes.get(&inst.class_id).map(|cl| cl.inst_size as u64)
-                    } else {
-                        None
-                    }
-                })
-                .sum();
-
-            println!(
-                "--- Pattern {} ({} instance{}, ~{} shallow) ---",
-                i + 1,
-                matching.len(),
-                if matching.len() == 1 { "" } else { "s" },
-                format_size(total_bytes),
-            );
-
-            if example_path.is_empty() {
-                println!("  <no path found from scheduler to this {label}>");
-            } else {
-                for (id, name) in example_path {
-                    println!("  {id:x} {name}");
-                }
+        // Display path: collapsed runs with counts, plus field annotations.
+        let mut full_path: Vec<(T, String)> = Vec::new();
+        let mut i = 0;
+        while i < raw.len() {
+            let (ele, ref name) = raw[i];
+            let annotation = &field_annotations[i];
+            let mut run = 1;
+            while i + run < raw.len() && raw[i + run].1 == *name {
+                run += 1;
             }
-            println!();
+            let base = if run > 1 { format!("{name} (×{run})") } else { name.clone() };
+            let display = if let Some(field) = annotation {
+                format!("{base}  (.{field})")
+            } else {
+                base
+            };
+            full_path.push((ele, display));
+            i += run;
+        }
+
+        let is_new = !pattern_terminals.contains_key(&sig);
+        pattern_terminals.entry(sig.clone()).or_default().insert(terminal);
+        if is_new {
+            pattern_order.push(sig.clone());
+            pattern_example.insert(sig, full_path);
         }
     }
 
-    Ok(any_exceeded)
+    // Most-common patterns first.
+    pattern_order.sort_by(|a, b| pattern_terminals[b].len().cmp(&pattern_terminals[a].len()));
+
+    println!(
+        "=== {} leaked instance{}, {} unique retention pattern{} ===\n",
+        candidates.len(),
+        if candidates.len() == 1 { "" } else { "s" },
+        pattern_order.len(),
+        if pattern_order.len() == 1 { "" } else { "s" }
+    );
+
+    for (i, sig) in pattern_order.iter().enumerate() {
+        let terminals = &pattern_terminals[sig];
+        let example_path = &pattern_example[sig];
+
+        let total_bytes: u64 = terminals
+            .iter()
+            .filter_map(|c| {
+                if let Some(HeapDumpEntry::InstanceDump(inst)) = inst_data.get(c) {
+                    classes.get(&inst.class_id).map(|cl| cl.inst_size as u64)
+                } else {
+                    None
+                }
+            })
+            .sum();
+
+        println!(
+            "--- Pattern {} ({} instance{}, ~{} shallow) ---",
+            i + 1,
+            terminals.len(),
+            if terminals.len() == 1 { "" } else { "s" },
+            format_size(total_bytes),
+        );
+
+        if example_path.is_empty() {
+            println!("  <no path found from scheduler>");
+        } else {
+            for (id, name) in example_path {
+                println!("  {id:x} {name}");
+            }
+        }
+        println!();
+    }
+
+    Ok(true)
 }
 
 const HEADER: &[u8; 19] = b"JAVA PROFILE 1.0.2\0";

--- a/rust/src/hprof/mod.rs
+++ b/rust/src/hprof/mod.rs
@@ -525,7 +525,7 @@ fn visit_prof<
     Ok(())
 }
 
-fn do_read_prof<'a, T: Id>(file: &'a [u8], file_len_hint: usize) -> Result<()> {
+fn do_read_prof<'a, T: Id>(file: &'a [u8]) -> Result<()> {
     use ClassNames::*;
 
     let str_dict = RefCell::new(IntMap::default());
@@ -533,10 +533,7 @@ fn do_read_prof<'a, T: Id>(file: &'a [u8], file_len_hint: usize) -> Result<()> {
     let mut class_names = IntMap::default();
     let mut gc_roots: IntMap<_, SmallVec<[GcRootData<T>; 2]>> = IntMap::default();
 
-    // Pre-size to avoid realloc spikes. Rough heuristic: field-ref edges dominate;
-    // cap at 256M entries (~4GB for u64 IDs) so we don't over-allocate on small heaps.
-    let edge_capacity = (file_len_hint / (size_of::<(T, T)>() * 4)).min(256 * 1024 * 1024);
-    let mut edges: Vec<(T, T)> = Vec::with_capacity(edge_capacity);
+    let mut edges: Vec<(T, T)> = Vec::new();
     let mut world_server_instances = Vec::new();
 
     let special_strings = vec![OnceCell::new(); Max as usize];
@@ -585,16 +582,16 @@ fn do_read_prof<'a, T: Id>(file: &'a [u8], file_len_hint: usize) -> Result<()> {
         |entry| {
             match entry {
                 HeapDumpEntry::ClassDump(class) => {
-                    // Only track static-field edges: a class object holding a reference to
-                    // some heap object via a static field is a real Java reference and can be
-                    // a leak root. Class hierarchy / classloader edges are JVM-implicit
-                    // relationships that don't represent Java field references and add
-                    // enormous noise to the graph (~4 edges per class, irrelevant to leaks).
                     for (_, static_value) in &class.statics {
                         if let JVMValue::Obj(child) = static_value {
                             insert_edge(*child, class.id);
                         }
                     }
+
+                    insert_edge(class.super_id, class.id);
+                    insert_edge(class.class_loader_id, class.id);
+                    insert_edge(class.signers_id, class.id);
+                    insert_edge(class.protection_domain_id, class.id);
 
                     let res = classes.insert(class.id, class);
                     debug_assert!(res.is_none());
@@ -602,10 +599,7 @@ fn do_read_prof<'a, T: Id>(file: &'a [u8], file_len_hint: usize) -> Result<()> {
                 HeapDumpEntry::InstanceDump(inst) => {
                     let class = classes.get(&inst.class_id).unwrap();
 
-                    // Intentionally NOT inserting a class→instance back-edge here.
-                    // That edge represents the JVM vtable pointer (implicit), not a Java
-                    // field reference. For a 16GB heap with ~700M instances it adds ~11GB
-                    // of edges that are never on a real scheduler→WorldServer leak path.
+                    insert_edge(class.id, inst.id);
 
                     if inst.class_id == get_class_id(WorldServerClass) {
                         world_server_instances.push(inst.id);
@@ -649,8 +643,7 @@ fn do_read_prof<'a, T: Id>(file: &'a [u8], file_len_hint: usize) -> Result<()> {
                     let len = arr.data.len() / size_of::<T>();
                     let mut buf = arr.data;
 
-                    // Not inserting arr.class_id→arr.id for the same reason as instances:
-                    // it's the JVM element-type pointer, not a Java reference on any leak path.
+                    insert_edge(arr.class_id, arr.id);
 
                     for _ in 0..len {
                         insert_edge(T::read_from(&mut buf)?, arr.id);
@@ -847,8 +840,6 @@ fn do_read_prof<'a, T: Id>(file: &'a [u8], file_len_hint: usize) -> Result<()> {
 const HEADER: &[u8; 19] = b"JAVA PROFILE 1.0.2\0";
 
 pub fn read_prof(mut hprof_file: &[u8]) -> Result<()> {
-    let file_len = hprof_file.len();
-
     let mut header = [0; HEADER.len()];
     hprof_file.read_exact(&mut header)?;
 
@@ -860,9 +851,9 @@ pub fn read_prof(mut hprof_file: &[u8]) -> Result<()> {
     let _micros = hprof_file.read_u64::<BigEndian>()?;
 
     if id_size == 4 {
-        do_read_prof::<u32>(hprof_file, file_len)?;
+        do_read_prof::<u32>(hprof_file)?;
     } else if id_size == 8 {
-        do_read_prof::<u64>(hprof_file, file_len)?;
+        do_read_prof::<u64>(hprof_file)?;
     } else {
         return Err(anyhow!("illegal id_size: {id_size}"));
     }

--- a/rust/src/hprof/mod.rs
+++ b/rust/src/hprof/mod.rs
@@ -558,7 +558,7 @@ fn madvise(file: &[u8], sequential: bool) {
     }
 }
 
-fn do_read_prof<'a, T: Id>(file: &'a [u8], min_leaked: usize, min_pattern_leaked: usize, normalize_inner_classes: bool, show_ids: bool) -> Result<bool> {
+fn do_read_prof<'a, T: Id>(file: &'a [u8], min_leaked: usize, min_pattern_leaked: usize, normalize_inner_classes: bool, show_ids: bool, json: bool) -> Result<bool> {
     use ClassNames::*;
 
     let str_dict = RefCell::new(IntMap::default());
@@ -983,51 +983,72 @@ fn do_read_prof<'a, T: Id>(file: &'a [u8], min_leaked: usize, min_pattern_leaked
         .filter(|sig| pattern_terminals[*sig].len() < min_pattern_leaked)
         .count();
     let suppressed_note = if suppressed > 0 {
-        format!(
-            " ({} suppressed by --min-pattern-leaked)",
-            suppressed
-        )
+        format!(" ({} suppressed by --min-pattern-leaked)", suppressed)
     } else {
         String::new()
     };
 
-    println!(
-        "=== {} leaked instance{}, {} unique retention pattern{}{} ===\n",
-        candidates.len(),
-        if candidates.len() == 1 { "" } else { "s" },
-        pattern_order.len(),
-        if pattern_order.len() == 1 { "" } else { "s" },
-        suppressed_note,
-    );
-
-    let mut display_index = 1usize;
-    for sig in pattern_order.iter() {
-        let terminals = &pattern_terminals[sig];
-        if terminals.len() < min_pattern_leaked {
-            continue;
-        }
-        let example_path = &pattern_example[sig];
-
-        println!(
-            "--- Pattern {} ({} instance{}) ---",
-            display_index,
-            terminals.len(),
-            if terminals.len() == 1 { "" } else { "s" },
+    if json {
+        // Summary goes to stderr so stdout is clean JSON.
+        eprintln!(
+            "=== {} leaked instance{}, {} unique retention pattern{}{} ===",
+            candidates.len(),
+            if candidates.len() == 1 { "" } else { "s" },
+            pattern_order.len(),
+            if pattern_order.len() == 1 { "" } else { "s" },
+            suppressed_note,
         );
-        display_index += 1;
+        // Serialize the already-compact display strings — same format as text output,
+        // just structured. Each chain entry is a display string like
+        // "java/util/HashMap$Node (×8)  (.key)" or "java/util/HashMap  (.table)".
+        let patterns: Vec<serde_json::Value> = pattern_order.iter()
+            .filter(|sig| pattern_terminals[*sig].len() >= min_pattern_leaked)
+            .map(|sig| {
+                let count = pattern_terminals[sig].len();
+                let chain: Vec<&str> = pattern_example[sig].iter().map(|(_, s)| s.as_str()).collect();
+                serde_json::json!({"instance_count": count, "chain": chain})
+            })
+            .collect();
+        println!("{}", serde_json::to_string(&patterns)?);
+    } else {
+        println!(
+            "=== {} leaked instance{}, {} unique retention pattern{}{} ===\n",
+            candidates.len(),
+            if candidates.len() == 1 { "" } else { "s" },
+            pattern_order.len(),
+            if pattern_order.len() == 1 { "" } else { "s" },
+            suppressed_note,
+        );
 
-        if example_path.is_empty() {
-            println!("  <no path found from scheduler>");
-        } else {
-            for (id, name) in example_path {
-                if show_ids {
-                    println!("  {id:x} {name}");
-                } else {
-                    println!("  {name}");
+        let mut display_index = 1usize;
+        for sig in pattern_order.iter() {
+            let terminals = &pattern_terminals[sig];
+            if terminals.len() < min_pattern_leaked {
+                continue;
+            }
+            let example_path = &pattern_example[sig];
+
+            println!(
+                "--- Pattern {} ({} instance{}) ---",
+                display_index,
+                terminals.len(),
+                if terminals.len() == 1 { "" } else { "s" },
+            );
+            display_index += 1;
+
+            if example_path.is_empty() {
+                println!("  <no path found from scheduler>");
+            } else {
+                for (id, name) in example_path {
+                    if show_ids {
+                        println!("  {id:x} {name}");
+                    } else {
+                        println!("  {name}");
+                    }
                 }
             }
+            println!();
         }
-        println!();
     }
 
     Ok(true)
@@ -1035,7 +1056,7 @@ fn do_read_prof<'a, T: Id>(file: &'a [u8], min_leaked: usize, min_pattern_leaked
 
 const HEADER: &[u8; 19] = b"JAVA PROFILE 1.0.2\0";
 
-pub fn read_prof(mut hprof_file: &[u8], min_leaked: usize, min_pattern_leaked: usize, normalize_inner_classes: bool, show_ids: bool) -> Result<bool> {
+pub fn read_prof(mut hprof_file: &[u8], min_leaked: usize, min_pattern_leaked: usize, normalize_inner_classes: bool, show_ids: bool, json: bool) -> Result<bool> {
     let mut header = [0; HEADER.len()];
     hprof_file.read_exact(&mut header)?;
 
@@ -1048,12 +1069,12 @@ pub fn read_prof(mut hprof_file: &[u8], min_leaked: usize, min_pattern_leaked: u
 
     if id_size == 4 {
         eprintln!("detected 4-byte object IDs (compressed OOPs)");
-        do_read_prof::<u32>(hprof_file, min_leaked, min_pattern_leaked, normalize_inner_classes, show_ids)
+        do_read_prof::<u32>(hprof_file, min_leaked, min_pattern_leaked, normalize_inner_classes, show_ids, json)
     } else if id_size == 8 {
         // Shifted OOP values for heaps ≤ 32 GB fit in u32, halving edge memory.
         // Fall back to u64 only if a value overflows (heap > 32 GB).
         eprintln!("detected 8-byte object IDs (uncompressed OOPs); using compact u32 storage");
-        do_read_prof::<OopId>(hprof_file, min_leaked, min_pattern_leaked, normalize_inner_classes, show_ids)
+        do_read_prof::<OopId>(hprof_file, min_leaked, min_pattern_leaked, normalize_inner_classes, show_ids, json)
     } else {
         Err(anyhow!("illegal id_size: {id_size}"))
     }

--- a/rust/src/hprof/mod.rs
+++ b/rust/src/hprof/mod.rs
@@ -539,7 +539,7 @@ fn format_size(bytes: u64) -> String {
     }
 }
 
-fn do_read_prof<'a, T: Id>(file: &'a [u8]) -> Result<()> {
+fn do_read_prof<'a, T: Id>(file: &'a [u8], min_leaked: usize) -> Result<bool> {
     use ClassNames::*;
 
     let str_dict = RefCell::new(IntMap::default());
@@ -754,10 +754,17 @@ fn do_read_prof<'a, T: Id>(file: &'a [u8]) -> Result<()> {
         },
     )?;
 
+    let mut any_exceeded = false;
+
     for (type_info, (candidates, candidate_paths)) in
         class_types.iter().zip(all_candidates.iter().zip(all_paths.iter()))
     {
         let label = type_info.0;
+
+        if candidates.len() < min_leaked {
+            continue;
+        }
+        any_exceeded = true;
 
         // Group shortest paths by class-name signature to deduplicate across all candidates.
         // Many candidates may be held alive by the same code pattern (same class chain),
@@ -911,12 +918,12 @@ fn do_read_prof<'a, T: Id>(file: &'a [u8]) -> Result<()> {
         }
     }
 
-    Ok(())
+    Ok(any_exceeded)
 }
 
 const HEADER: &[u8; 19] = b"JAVA PROFILE 1.0.2\0";
 
-pub fn read_prof(mut hprof_file: &[u8]) -> Result<()> {
+pub fn read_prof(mut hprof_file: &[u8], min_leaked: usize) -> Result<bool> {
     let mut header = [0; HEADER.len()];
     hprof_file.read_exact(&mut header)?;
 
@@ -928,12 +935,10 @@ pub fn read_prof(mut hprof_file: &[u8]) -> Result<()> {
     let _micros = hprof_file.read_u64::<BigEndian>()?;
 
     if id_size == 4 {
-        do_read_prof::<u32>(hprof_file)?;
+        do_read_prof::<u32>(hprof_file, min_leaked)
     } else if id_size == 8 {
-        do_read_prof::<u64>(hprof_file)?;
+        do_read_prof::<u64>(hprof_file, min_leaked)
     } else {
-        return Err(anyhow!("illegal id_size: {id_size}"));
+        Err(anyhow!("illegal id_size: {id_size}"))
     }
-
-    Ok(())
 }

--- a/rust/src/hprof/mod.rs
+++ b/rust/src/hprof/mod.rs
@@ -344,7 +344,7 @@ impl<'a, T: Id> HeapDumpRecord<'a, T> for GcObjArrayDump<'a, T> {
             id,
             stacktrace_seq,
             class_id,
-            data: read_nocopy(cur, len * size_of::<T>())?,
+            data: read_nocopy(cur, len * T::FILE_SIZE)?,
         })
     }
 }
@@ -681,7 +681,7 @@ fn do_read_prof<'a, T: Id>(file: &'a [u8], min_leaked: usize) -> Result<bool> {
                     })?;
                 }
                 HeapDumpEntry::ObjArrayDump(arr) => {
-                    let len = arr.data.len() / size_of::<T>();
+                    let len = arr.data.len() / T::FILE_SIZE;
                     let mut buf = arr.data;
 
                     insert_edge(arr.class_id, arr.id);

--- a/rust/src/hprof/mod.rs
+++ b/rust/src/hprof/mod.rs
@@ -850,7 +850,7 @@ fn do_read_prof<'a, T: Id>(file: &'a [u8], min_leaked: usize, min_pattern_leaked
     // into the CraftPlayer's pattern rather than creating a redundant WorldServer entry.
     let mut pattern_order: Vec<Vec<String>> = Vec::new();
     let mut pattern_terminals: IntMap<Vec<String>, IntSet<T>> = IntMap::default();
-    let mut pattern_example: IntMap<Vec<String>, Vec<(T, String)>> = IntMap::default();
+    let mut pattern_example: IntMap<Vec<String>, Vec<(T, String, Option<String>)>> = IntMap::default();
     let mut pattern_example_score: IntMap<Vec<String>, usize> = IntMap::default();
 
     for (path, &candidate) in izip!(candidate_paths.iter(), candidates.iter()) {
@@ -894,8 +894,14 @@ fn do_read_prof<'a, T: Id>(file: &'a [u8], min_leaked: usize, min_pattern_leaked
                     let class = classes.get(&inst.class_id).unwrap();
                     let class_name_id = class_names.get(&class.id).unwrap();
                     let dict = str_dict.borrow();
-                    let class_name = dict.get(class_name_id).unwrap();
-                    format!("{}[]", str::from_utf8(class_name)?)
+                    let class_name_bytes = dict.get(class_name_id).unwrap();
+                    let class_name = str::from_utf8(class_name_bytes)?;
+                    // Simplify JVM array notation: [Ljava/lang/Object; -> java/lang/Object[]
+                    if class_name.starts_with("[L") && class_name.ends_with(';') {
+                        format!("{}[]", &class_name[2..class_name.len() - 1])
+                    } else {
+                        format!("{}[]", class_name)
+                    }
                 }
                 None => {
                     let class = classes.get(ele).unwrap();
@@ -926,9 +932,9 @@ fn do_read_prof<'a, T: Id>(file: &'a [u8], min_leaked: usize, min_pattern_leaked
         }
 
         // Signature: normalize inner class names (if enabled), then collapse
-        // consecutive same-class runs. Normalization strips the $InnerClass suffix so
-        // that e.g. HashMap$Node, HashMap$TreeNode, BossAbilityGroup$1/$2 all map to
-        // the same pattern entry.
+        // consecutive same-class runs. Normalization strips the $InnerClass suffix and
+        // the Class<> wrapper so that e.g. HashMap$Node, HashMap$TreeNode,
+        // BossAbilityGroup$1/$2, and Class<X>/X-instance pairs all map to the same sig.
         let mut sig: Vec<String> = Vec::new();
         for (_, name) in &raw {
             let norm = if normalize_inner_classes {
@@ -941,24 +947,37 @@ fn do_read_prof<'a, T: Id>(file: &'a [u8], min_leaked: usize, min_pattern_leaked
             }
         }
 
-        // Display path: collapsed runs with counts, plus field annotations.
-        let mut full_path: Vec<(T, String)> = Vec::new();
+        // Display path: collapsed runs (count not shown), field annotations, and in
+        // normalize mode Class<X>+X instance pairs merged into one entry.
+        let mut full_path: Vec<(T, String, Option<String>)> = Vec::new();
         let mut i = 0;
         while i < raw.len() {
-            let (ele, ref name) = raw[i];
-            let annotation = &field_annotations[i];
+            let name = raw[i].1.clone();
+            let ele = raw[i].0;
+            let annotation = field_annotations[i].clone();
             let mut run = 1;
-            while i + run < raw.len() && raw[i + run].1 == *name {
+            while i + run < raw.len() && raw[i + run].1 == name {
                 run += 1;
             }
-            let base = if run > 1 { format!("{name} (×{run})") } else { name.clone() };
-            let display = if let Some(field) = annotation {
-                format!("{base}  (.{field})")
-            } else {
-                base
-            };
-            full_path.push((ele, display));
             i += run;
+            // In normalize mode: collapse Class<X> + X instance into one entry.
+            // The class-object entry carries the static field_name; the following
+            // instance entry is only the class-pointer edge and carries no field name.
+            let (class_name, field_name) = if normalize_inner_classes {
+                if let Some(inner) = strip_class_wrapper(&name) {
+                    if i < raw.len() && raw[i].1 == inner {
+                        i += 1;
+                        (inner.to_string(), annotation)
+                    } else {
+                        (name, annotation)
+                    }
+                } else {
+                    (name, annotation)
+                }
+            } else {
+                (name, annotation)
+            };
+            full_path.push((ele, class_name, field_name));
         }
 
         let annotation_score = field_annotations.iter().filter(|a| a.is_some()).count();
@@ -998,14 +1017,15 @@ fn do_read_prof<'a, T: Id>(file: &'a [u8], min_leaked: usize, min_pattern_leaked
             if pattern_order.len() == 1 { "" } else { "s" },
             suppressed_note,
         );
-        // Serialize the already-compact display strings — same format as text output,
-        // just structured. Each chain entry is a display string like
-        // "java/util/HashMap$Node (×8)  (.key)" or "java/util/HashMap  (.table)".
         let patterns: Vec<serde_json::Value> = pattern_order.iter()
             .filter(|sig| pattern_terminals[*sig].len() >= min_pattern_leaked)
             .map(|sig| {
                 let count = pattern_terminals[sig].len();
-                let chain: Vec<&str> = pattern_example[sig].iter().map(|(_, s)| s.as_str()).collect();
+                let chain: Vec<serde_json::Value> = pattern_example[sig].iter()
+                    .map(|(_, class_name, field_name)| {
+                        serde_json::json!({"class_name": class_name, "field_name": field_name})
+                    })
+                    .collect();
                 serde_json::json!({"instance_count": count, "chain": chain})
             })
             .collect();
@@ -1039,11 +1059,16 @@ fn do_read_prof<'a, T: Id>(file: &'a [u8], min_leaked: usize, min_pattern_leaked
             if example_path.is_empty() {
                 println!("  <no path found from scheduler>");
             } else {
-                for (id, name) in example_path {
-                    if show_ids {
-                        println!("  {id:x} {name}");
+                for (id, class_name, field_name) in example_path {
+                    let display = if let Some(field) = field_name {
+                        format!("{class_name}  (.{field})")
                     } else {
-                        println!("  {name}");
+                        class_name.clone()
+                    };
+                    if show_ids {
+                        println!("  {id:x} {display}");
+                    } else {
+                        println!("  {display}");
                     }
                 }
             }
@@ -1080,12 +1105,21 @@ pub fn read_prof(mut hprof_file: &[u8], min_leaked: usize, min_pattern_leaked: u
     }
 }
 
+fn strip_class_wrapper(name: &str) -> Option<&str> {
+    if name.starts_with("Class<") && name.ends_with('>') {
+        Some(&name[6..name.len() - 1])
+    } else {
+        None
+    }
+}
+
 fn normalize_class_name(name: &str) -> String {
+    // Strip Class<> wrapper so class objects group with their instances in the sig.
+    let name = strip_class_wrapper(name).unwrap_or(name);
     // Strip inner class suffix (everything from the last '$' to the next ';', '>', or end).
-    // Handles three forms produced by the path-resolution code:
-    //   "org/foo/Bar$Inner"        -> "org/foo/Bar"
-    //   "[Lorg/foo/Bar$Inner;[]"   -> "[Lorg/foo/Bar;[]"
-    //   "Class<org/foo/Bar$Inner>" -> "Class<org/foo/Bar>"
+    //   "org/foo/Bar$Inner"  -> "org/foo/Bar"
+    //   "org/foo/Bar$1"      -> "org/foo/Bar"
+    //   "java/lang/Object[]" -> "java/lang/Object[]"  (no '$', unchanged)
     if let Some(dollar) = name.rfind('$') {
         let mut result = name[..dollar].to_string();
         let rest = &name[dollar + 1..];

--- a/rust/src/hprof/mod.rs
+++ b/rust/src/hprof/mod.rs
@@ -586,7 +586,9 @@ fn do_read_prof<'a, T: Id>(file: &'a [u8], min_leaked: usize, min_pattern_leaked
         edges.push((child, parent));
     };
 
-    let get_class_id = |id: ClassNames| *class_ids[id as usize].get().unwrap();
+    // Returns T::NULL (0) when a special class wasn't found in the heap dump, which makes every
+    // comparison against it false — effectively disabling that detection path gracefully.
+    let get_class_id = |id: ClassNames| class_ids[id as usize].get().copied().unwrap_or(T::NULL);
 
     eprintln!("parsing heap dump");
 
@@ -607,7 +609,7 @@ fn do_read_prof<'a, T: Id>(file: &'a [u8], min_leaked: usize, min_pattern_leaked
             debug_assert!(res.is_none());
 
             for (idx, v) in special_strings.iter().enumerate() {
-                if name_id == *v.get().unwrap() {
+                if v.get().map_or(false, |s| name_id == *s) {
                     let res = class_ids[idx].set(obj_id);
                     debug_assert!(res.is_ok());
                 }
@@ -696,6 +698,30 @@ fn do_read_prof<'a, T: Id>(file: &'a [u8], min_leaked: usize, min_pattern_leaked
             Ok(())
         },
     )?;
+
+    // Warn when detection-critical classes were not found. This usually means the hardcoded
+    // class name mappings (currently targeting v1_20_R3) are out of date for the Minecraft
+    // version that produced this heap dump.
+    let scheduler_found = class_ids[CraftSchedulerClass as usize].get().is_some()
+        || class_ids[CraftAsyncSchedulerClass as usize].get().is_some();
+    let leak_targets_found = class_ids[WorldServerClass as usize].get().is_some()
+        || class_ids[EntityPlayerClass as usize].get().is_some()
+        || class_ids[CraftPlayerClass as usize].get().is_some();
+    if !scheduler_found {
+        eprintln!(
+            "warning: neither CraftScheduler nor CraftAsyncScheduler was found in the heap dump"
+        );
+        eprintln!(
+            "         no leak root sources can be identified — all paths-to-root will be empty"
+        );
+        eprintln!("         the class name mappings may be out of date (currently target v1_20_R3)");
+    }
+    if !leak_targets_found {
+        eprintln!(
+            "warning: no leak target classes (WorldServer, EntityPlayer, CraftPlayer) were found"
+        );
+        eprintln!("         the class name mappings may be out of date (currently target v1_20_R3)");
+    }
 
     eprintln!("clean graph");
 

--- a/rust/src/hprof/mod.rs
+++ b/rust/src/hprof/mod.rs
@@ -457,6 +457,8 @@ enum ClassNames {
     CraftAsyncSchedulerClass,
     CraftSchedulerClass,
     ReferenceClass,
+    EntityPlayerClass,
+    CraftPlayerClass,
     Max,
 }
 
@@ -468,7 +470,9 @@ static CLASS_NAMES: phf::Map<&'static [u8], ClassNames> = phf_map! {
     b"org/bukkit/craftbukkit/v1_20_R3/CraftServer" => ClassNames::CraftServerClass,
     b"org/bukkit/craftbukkit/v1_20_R3/scheduler/CraftAsyncScheduler" => ClassNames::CraftAsyncSchedulerClass,
     b"org/bukkit/craftbukkit/v1_20_R3/scheduler/CraftScheduler" => ClassNames::CraftSchedulerClass,
-    b"java/lang/ref/Reference" => ClassNames::ReferenceClass
+    b"java/lang/ref/Reference" => ClassNames::ReferenceClass,
+    b"net/minecraft/server/level/EntityPlayer" => ClassNames::EntityPlayerClass,
+    b"org/bukkit/craftbukkit/v1_20_R3/entity/CraftPlayer" => ClassNames::CraftPlayerClass
 };
 
 fn visit_prof<
@@ -535,6 +539,8 @@ fn do_read_prof<'a, T: Id>(file: &'a [u8]) -> Result<()> {
 
     let mut edges: Vec<(T, T)> = Vec::new();
     let mut world_server_instances = Vec::new();
+    let mut entity_player_instances = Vec::new();
+    let mut craft_player_instances = Vec::new();
 
     let special_strings = vec![OnceCell::new(); Max as usize];
     let class_ids = vec![OnceCell::new(); Max as usize];
@@ -603,6 +609,10 @@ fn do_read_prof<'a, T: Id>(file: &'a [u8]) -> Result<()> {
 
                     if inst.class_id == get_class_id(WorldServerClass) {
                         world_server_instances.push(inst.id);
+                    } else if inst.class_id == get_class_id(EntityPlayerClass) {
+                        entity_player_instances.push(inst.id);
+                    } else if inst.class_id == get_class_id(CraftPlayerClass) {
+                        craft_player_instances.push(inst.id);
                     } else if inst.class_id == get_class_id(DedicatedServerClass) {
                         class.iter_fields(inst.data, &classes, |_, name_id, value| {
                             if str_dict.borrow()[&name_id] == b"Q"
@@ -660,37 +670,44 @@ fn do_read_prof<'a, T: Id>(file: &'a [u8]) -> Result<()> {
 
     clean_graph(&mut edges);
 
-    eprintln!("finding paths to root");
+    let class_types: [(&'static str, &[T]); 3] = [
+        ("WorldServer", &world_server_instances),
+        ("EntityPlayer", &entity_player_instances),
+        ("CraftPlayer", &craft_player_instances),
+    ];
 
-    eprintln!("found {:?} instances", world_server_instances.len());
+    let mut all_candidates: Vec<Vec<T>> = Vec::new();
+    let mut all_paths: Vec<Vec<Vec<T>>> = Vec::new();
 
-    let globally_reachable = is_reachable(&edges, |f| gc_roots.contains_key(&f), &world_server_instances);
+    for (label, instances) in &class_types {
+        eprintln!("finding paths to root for {label}");
+        eprintln!("found {} instances", instances.len());
 
-    let non_leaked_instances = is_reachable(&edges, |f| non_leak_root_sources.contains(&f), &world_server_instances);
+        let globally_reachable = is_reachable(&edges, |f| gc_roots.contains_key(&f), instances);
+        let non_leaked_instances =
+            is_reachable(&edges, |f| non_leak_root_sources.contains(&f), instances);
 
-    let mut leak_candidates = Vec::new();
-
-    for (inst, global, non_leak) in
-        izip!(world_server_instances.iter(), globally_reachable.iter(), non_leaked_instances.iter(),)
-    {
-        if !*global {
-            continue;
+        let mut candidates = Vec::new();
+        for (inst, global, non_leak) in
+            izip!(instances.iter(), globally_reachable.iter(), non_leaked_instances.iter())
+        {
+            if !*global || *non_leak {
+                continue;
+            }
+            candidates.push(*inst);
         }
 
-        if *non_leak {
-            continue;
-        }
+        eprintln!("finding leaked {label} paths-to-root");
+        eprintln!("found {} likely leak candidates", candidates.len());
 
-        leak_candidates.push(*inst);
+        let paths: Vec<Vec<T>> = candidates
+            .iter()
+            .map(|&c| find_shortest_path(&edges, |f| leak_root_sources.contains(&f), c))
+            .collect();
+
+        all_candidates.push(candidates);
+        all_paths.push(paths);
     }
-
-    eprintln!("finding leaked object paths-to-root");
-    eprintln!("found {} likely leak candidates", leak_candidates.len());
-
-    let candidate_paths: Vec<Vec<T>> = leak_candidates
-        .iter()
-        .map(|&c| find_shortest_path(&edges, |f| leak_root_sources.contains(&f), c))
-        .collect();
 
     eprintln!("re-gathering instance data");
 
@@ -698,7 +715,7 @@ fn do_read_prof<'a, T: Id>(file: &'a [u8]) -> Result<()> {
 
     let mut relevant_inst: IntSet<T> = IntSet::default();
     let mut inst_data: IntMap<T, HeapDumpEntry<'a, T>> = IntMap::default();
-    relevant_inst.extend(candidate_paths.iter().flatten().copied());
+    relevant_inst.extend(all_paths.iter().flatten().flatten().copied());
 
     let mut on_data = |id: T, data: HeapDumpEntry<'a, T>| {
         if relevant_inst.contains(&id) {
@@ -721,117 +738,124 @@ fn do_read_prof<'a, T: Id>(file: &'a [u8]) -> Result<()> {
         },
     )?;
 
-    // Group shortest paths by class-name signature to deduplicate across all candidates.
-    // Many candidates may be held alive by the same code pattern (same class chain),
-    // differing only in which specific instances are involved.
-    let mut pattern_order: Vec<Vec<String>> = Vec::new();
-    let mut pattern_candidates: IntMap<Vec<String>, IntSet<T>> = IntMap::default();
-    let mut pattern_example: IntMap<Vec<String>, Vec<(T, String)>> = IntMap::default();
+    for (type_info, (candidates, candidate_paths)) in
+        class_types.iter().zip(all_candidates.iter().zip(all_paths.iter()))
+    {
+        let label = type_info.0;
 
-    for (path, &candidate) in izip!(candidate_paths.iter(), leak_candidates.iter()) {
-        if path.is_empty() {
-            let sig = vec!["<no path found>".to_string()];
+        // Group shortest paths by class-name signature to deduplicate across all candidates.
+        // Many candidates may be held alive by the same code pattern (same class chain),
+        // differing only in which specific instances are involved.
+        let mut pattern_order: Vec<Vec<String>> = Vec::new();
+        let mut pattern_candidates: IntMap<Vec<String>, IntSet<T>> = IntMap::default();
+        let mut pattern_example: IntMap<Vec<String>, Vec<(T, String)>> = IntMap::default();
+
+        for (path, &candidate) in izip!(candidate_paths.iter(), candidates.iter()) {
+            if path.is_empty() {
+                let sig = vec!["<no path found>".to_string()];
+                let is_new = !pattern_candidates.contains_key(&sig);
+                pattern_candidates.entry(sig.clone()).or_default().insert(candidate);
+                if is_new {
+                    pattern_order.push(sig.clone());
+                    pattern_example.insert(sig, vec![]);
+                }
+                continue;
+            }
+
+            // Resolve class names for every element in the path.
+            let mut raw: Vec<(T, String)> = Vec::new();
+            for ele in path {
+                let name: String = match inst_data.get(ele) {
+                    Some(HeapDumpEntry::InstanceDump(inst)) => {
+                        let class = classes.get(&inst.class_id).unwrap();
+                        let class_name_id = class_names.get(&class.id).unwrap();
+                        let dict = str_dict.borrow();
+                        let class_name = dict.get(class_name_id).unwrap();
+                        str::from_utf8(class_name)?.to_string()
+                    }
+                    Some(HeapDumpEntry::ObjArrayDump(inst)) => {
+                        let class = classes.get(&inst.class_id).unwrap();
+                        let class_name_id = class_names.get(&class.id).unwrap();
+                        let dict = str_dict.borrow();
+                        let class_name = dict.get(class_name_id).unwrap();
+                        format!("{}[]", str::from_utf8(class_name)?)
+                    }
+                    None => {
+                        let class = classes.get(ele).unwrap();
+                        let class_name_id = class_names.get(&class.id).unwrap();
+                        let dict = str_dict.borrow();
+                        let class_name = dict.get(class_name_id).unwrap();
+                        format!("Class<{}>", str::from_utf8(class_name)?)
+                    }
+                    _ => unreachable!(),
+                };
+                raw.push((*ele, name));
+            }
+
+            // Signature: collapse consecutive same-class runs to one entry so paths
+            // that differ only in how many HashMap$Node / TreeNode hops the BFS
+            // traversed (varies by hash-bucket depth) map to the same pattern.
+            let mut sig: Vec<String> = Vec::new();
+            for (_, name) in &raw {
+                if sig.last().map_or(true, |last| last != name) {
+                    sig.push(name.clone());
+                }
+            }
+
+            // Display path: same collapsing, but annotate runs with their count.
+            let mut full_path: Vec<(T, String)> = Vec::new();
+            let mut i = 0;
+            while i < raw.len() {
+                let (ele, ref name) = raw[i];
+                let mut run = 1;
+                while i + run < raw.len() && raw[i + run].1 == *name {
+                    run += 1;
+                }
+                let display = if run > 1 { format!("{name} (×{run})") } else { name.clone() };
+                full_path.push((ele, display));
+                i += run;
+            }
+
             let is_new = !pattern_candidates.contains_key(&sig);
             pattern_candidates.entry(sig.clone()).or_default().insert(candidate);
             if is_new {
                 pattern_order.push(sig.clone());
-                pattern_example.insert(sig, vec![]);
-            }
-            continue;
-        }
-
-        // Resolve class names for every element in the path.
-        let mut raw: Vec<(T, String)> = Vec::new();
-        for ele in path {
-            let name: String = match inst_data.get(ele) {
-                Some(HeapDumpEntry::InstanceDump(inst)) => {
-                    let class = classes.get(&inst.class_id).unwrap();
-                    let class_name_id = class_names.get(&class.id).unwrap();
-                    let dict = str_dict.borrow();
-                    let class_name = dict.get(class_name_id).unwrap();
-                    str::from_utf8(class_name)?.to_string()
-                }
-                Some(HeapDumpEntry::ObjArrayDump(inst)) => {
-                    let class = classes.get(&inst.class_id).unwrap();
-                    let class_name_id = class_names.get(&class.id).unwrap();
-                    let dict = str_dict.borrow();
-                    let class_name = dict.get(class_name_id).unwrap();
-                    format!("{}[]", str::from_utf8(class_name)?)
-                }
-                None => {
-                    let class = classes.get(ele).unwrap();
-                    let class_name_id = class_names.get(&class.id).unwrap();
-                    let dict = str_dict.borrow();
-                    let class_name = dict.get(class_name_id).unwrap();
-                    format!("Class<{}>", str::from_utf8(class_name)?)
-                }
-                _ => unreachable!(),
-            };
-            raw.push((*ele, name));
-        }
-
-        // Signature: collapse consecutive same-class runs to one entry so paths
-        // that differ only in how many HashMap$Node / TreeNode hops the BFS
-        // traversed (varies by hash-bucket depth) map to the same pattern.
-        let mut sig: Vec<String> = Vec::new();
-        for (_, name) in &raw {
-            if sig.last().map_or(true, |last| last != name) {
-                sig.push(name.clone());
+                pattern_example.insert(sig, full_path);
             }
         }
 
-        // Display path: same collapsing, but annotate runs with their count.
-        let mut full_path: Vec<(T, String)> = Vec::new();
-        let mut i = 0;
-        while i < raw.len() {
-            let (ele, ref name) = raw[i];
-            let mut run = 1;
-            while i + run < raw.len() && raw[i + run].1 == *name {
-                run += 1;
-            }
-            let display = if run > 1 { format!("{name} (×{run})") } else { name.clone() };
-            full_path.push((ele, display));
-            i += run;
-        }
-
-        let is_new = !pattern_candidates.contains_key(&sig);
-        pattern_candidates.entry(sig.clone()).or_default().insert(candidate);
-        if is_new {
-            pattern_order.push(sig.clone());
-            pattern_example.insert(sig, full_path);
-        }
-    }
-
-    // Most-common patterns first.
-    pattern_order.sort_by(|a, b| pattern_candidates[b].len().cmp(&pattern_candidates[a].len()));
-
-    println!(
-        "=== {} leaked WorldServer instance{}, {} unique retention pattern{} ===\n",
-        leak_candidates.len(),
-        if leak_candidates.len() == 1 { "" } else { "s" },
-        pattern_order.len(),
-        if pattern_order.len() == 1 { "" } else { "s" }
-    );
-
-    for (i, sig) in pattern_order.iter().enumerate() {
-        let candidates = &pattern_candidates[sig];
-        let example_path = &pattern_example[sig];
+        // Most-common patterns first.
+        pattern_order.sort_by(|a, b| pattern_candidates[b].len().cmp(&pattern_candidates[a].len()));
 
         println!(
-            "--- Pattern {} ({} instance{}) ---",
-            i + 1,
+            "=== {} leaked {} instance{}, {} unique retention pattern{} ===\n",
             candidates.len(),
-            if candidates.len() == 1 { "" } else { "s" }
+            label,
+            if candidates.len() == 1 { "" } else { "s" },
+            pattern_order.len(),
+            if pattern_order.len() == 1 { "" } else { "s" }
         );
 
-        if example_path.is_empty() {
-            println!("  <no path found from scheduler to this WorldServer>");
-        } else {
-            for (id, name) in example_path {
-                println!("  {id:x} {name}");
+        for (i, sig) in pattern_order.iter().enumerate() {
+            let matching = &pattern_candidates[sig];
+            let example_path = &pattern_example[sig];
+
+            println!(
+                "--- Pattern {} ({} instance{}) ---",
+                i + 1,
+                matching.len(),
+                if matching.len() == 1 { "" } else { "s" }
+            );
+
+            if example_path.is_empty() {
+                println!("  <no path found from scheduler to this {label}>");
+            } else {
+                for (id, name) in example_path {
+                    println!("  {id:x} {name}");
+                }
             }
+            println!();
         }
-        println!();
     }
 
     Ok(())

--- a/rust/src/hprof/mod.rs
+++ b/rust/src/hprof/mod.rs
@@ -525,7 +525,7 @@ fn visit_prof<
     Ok(())
 }
 
-fn do_read_prof<'a, T: Id>(file: &'a [u8]) -> Result<()> {
+fn do_read_prof<'a, T: Id>(file: &'a [u8], file_len_hint: usize) -> Result<()> {
     use ClassNames::*;
 
     let str_dict = RefCell::new(IntMap::default());
@@ -533,7 +533,10 @@ fn do_read_prof<'a, T: Id>(file: &'a [u8]) -> Result<()> {
     let mut class_names = IntMap::default();
     let mut gc_roots: IntMap<_, SmallVec<[GcRootData<T>; 2]>> = IntMap::default();
 
-    let mut edges: Vec<(T, T)> = Vec::new();
+    // Pre-size to avoid realloc spikes. Rough heuristic: field-ref edges dominate;
+    // cap at 256M entries (~4GB for u64 IDs) so we don't over-allocate on small heaps.
+    let edge_capacity = (file_len_hint / (size_of::<(T, T)>() * 4)).min(256 * 1024 * 1024);
+    let mut edges: Vec<(T, T)> = Vec::with_capacity(edge_capacity);
     let mut world_server_instances = Vec::new();
 
     let special_strings = vec![OnceCell::new(); Max as usize];
@@ -582,16 +585,16 @@ fn do_read_prof<'a, T: Id>(file: &'a [u8]) -> Result<()> {
         |entry| {
             match entry {
                 HeapDumpEntry::ClassDump(class) => {
+                    // Only track static-field edges: a class object holding a reference to
+                    // some heap object via a static field is a real Java reference and can be
+                    // a leak root. Class hierarchy / classloader edges are JVM-implicit
+                    // relationships that don't represent Java field references and add
+                    // enormous noise to the graph (~4 edges per class, irrelevant to leaks).
                     for (_, static_value) in &class.statics {
                         if let JVMValue::Obj(child) = static_value {
                             insert_edge(*child, class.id);
                         }
                     }
-
-                    insert_edge(class.super_id, class.id);
-                    insert_edge(class.class_loader_id, class.id);
-                    insert_edge(class.signers_id, class.id);
-                    insert_edge(class.protection_domain_id, class.id);
 
                     let res = classes.insert(class.id, class);
                     debug_assert!(res.is_none());
@@ -599,7 +602,10 @@ fn do_read_prof<'a, T: Id>(file: &'a [u8]) -> Result<()> {
                 HeapDumpEntry::InstanceDump(inst) => {
                     let class = classes.get(&inst.class_id).unwrap();
 
-                    insert_edge(class.id, inst.id);
+                    // Intentionally NOT inserting a class→instance back-edge here.
+                    // That edge represents the JVM vtable pointer (implicit), not a Java
+                    // field reference. For a 16GB heap with ~700M instances it adds ~11GB
+                    // of edges that are never on a real scheduler→WorldServer leak path.
 
                     if inst.class_id == get_class_id(WorldServerClass) {
                         world_server_instances.push(inst.id);
@@ -643,7 +649,8 @@ fn do_read_prof<'a, T: Id>(file: &'a [u8]) -> Result<()> {
                     let len = arr.data.len() / size_of::<T>();
                     let mut buf = arr.data;
 
-                    insert_edge(arr.class_id, arr.id);
+                    // Not inserting arr.class_id→arr.id for the same reason as instances:
+                    // it's the JVM element-type pointer, not a Java reference on any leak path.
 
                     for _ in 0..len {
                         insert_edge(T::read_from(&mut buf)?, arr.id);
@@ -820,6 +827,8 @@ fn do_read_prof<'a, T: Id>(file: &'a [u8]) -> Result<()> {
 const HEADER: &[u8; 19] = b"JAVA PROFILE 1.0.2\0";
 
 pub fn read_prof(mut hprof_file: &[u8]) -> Result<()> {
+    let file_len = hprof_file.len();
+
     let mut header = [0; HEADER.len()];
     hprof_file.read_exact(&mut header)?;
 
@@ -831,9 +840,9 @@ pub fn read_prof(mut hprof_file: &[u8]) -> Result<()> {
     let _micros = hprof_file.read_u64::<BigEndian>()?;
 
     if id_size == 4 {
-        do_read_prof::<u32>(hprof_file)?;
+        do_read_prof::<u32>(hprof_file, file_len)?;
     } else if id_size == 8 {
-        do_read_prof::<u64>(hprof_file)?;
+        do_read_prof::<u64>(hprof_file, file_len)?;
     } else {
         return Err(anyhow!("illegal id_size: {id_size}"));
     }

--- a/rust/src/hprof/mod.rs
+++ b/rust/src/hprof/mod.rs
@@ -558,7 +558,7 @@ fn madvise(file: &[u8], sequential: bool) {
     }
 }
 
-fn do_read_prof<'a, T: Id>(file: &'a [u8], min_leaked: usize) -> Result<bool> {
+fn do_read_prof<'a, T: Id>(file: &'a [u8], min_leaked: usize, normalize_inner_classes: bool, show_ids: bool) -> Result<bool> {
     use ClassNames::*;
 
     let str_dict = RefCell::new(IntMap::default());
@@ -898,12 +898,19 @@ fn do_read_prof<'a, T: Id>(file: &'a [u8], min_leaked: usize) -> Result<bool> {
             field_annotations.push(annotation);
         }
 
-        // Signature: collapse consecutive same-class runs so paths differing only
-        // in HashMap$Node / TreeNode depth map to the same pattern.
+        // Signature: normalize inner class names (if enabled), then collapse
+        // consecutive same-class runs. Normalization strips the $InnerClass suffix so
+        // that e.g. HashMap$Node, HashMap$TreeNode, BossAbilityGroup$1/$2 all map to
+        // the same pattern entry.
         let mut sig: Vec<String> = Vec::new();
         for (_, name) in &raw {
-            if sig.last().map_or(true, |last| last != name) {
-                sig.push(name.clone());
+            let norm = if normalize_inner_classes {
+                normalize_class_name(name)
+            } else {
+                name.clone()
+            };
+            if sig.last().map_or(true, |last| last != &norm) {
+                sig.push(norm);
             }
         }
 
@@ -961,7 +968,11 @@ fn do_read_prof<'a, T: Id>(file: &'a [u8], min_leaked: usize) -> Result<bool> {
             println!("  <no path found from scheduler>");
         } else {
             for (id, name) in example_path {
-                println!("  {id:x} {name}");
+                if show_ids {
+                    println!("  {id:x} {name}");
+                } else {
+                    println!("  {name}");
+                }
             }
         }
         println!();
@@ -972,7 +983,7 @@ fn do_read_prof<'a, T: Id>(file: &'a [u8], min_leaked: usize) -> Result<bool> {
 
 const HEADER: &[u8; 19] = b"JAVA PROFILE 1.0.2\0";
 
-pub fn read_prof(mut hprof_file: &[u8], min_leaked: usize) -> Result<bool> {
+pub fn read_prof(mut hprof_file: &[u8], min_leaked: usize, normalize_inner_classes: bool, show_ids: bool) -> Result<bool> {
     let mut header = [0; HEADER.len()];
     hprof_file.read_exact(&mut header)?;
 
@@ -985,13 +996,30 @@ pub fn read_prof(mut hprof_file: &[u8], min_leaked: usize) -> Result<bool> {
 
     if id_size == 4 {
         eprintln!("detected 4-byte object IDs (compressed OOPs)");
-        do_read_prof::<u32>(hprof_file, min_leaked)
+        do_read_prof::<u32>(hprof_file, min_leaked, normalize_inner_classes, show_ids)
     } else if id_size == 8 {
         // Shifted OOP values for heaps ≤ 32 GB fit in u32, halving edge memory.
         // Fall back to u64 only if a value overflows (heap > 32 GB).
         eprintln!("detected 8-byte object IDs (uncompressed OOPs); using compact u32 storage");
-        do_read_prof::<OopId>(hprof_file, min_leaked)
+        do_read_prof::<OopId>(hprof_file, min_leaked, normalize_inner_classes, show_ids)
     } else {
         Err(anyhow!("illegal id_size: {id_size}"))
+    }
+}
+
+fn normalize_class_name(name: &str) -> String {
+    // Strip inner class suffix (everything from the last '$' to the next ';', '>', or end).
+    // Handles three forms produced by the path-resolution code:
+    //   "org/foo/Bar$Inner"        -> "org/foo/Bar"
+    //   "[Lorg/foo/Bar$Inner;[]"   -> "[Lorg/foo/Bar;[]"
+    //   "Class<org/foo/Bar$Inner>" -> "Class<org/foo/Bar>"
+    if let Some(dollar) = name.rfind('$') {
+        let mut result = name[..dollar].to_string();
+        let rest = &name[dollar + 1..];
+        let skip = rest.find([';', '>']).unwrap_or(rest.len());
+        result.push_str(&rest[skip..]);
+        result
+    } else {
+        name.to_string()
     }
 }

--- a/rust/src/hprof/mod.rs
+++ b/rust/src/hprof/mod.rs
@@ -687,7 +687,7 @@ fn do_read_prof<'a, T: Id>(file: &'a [u8]) -> Result<()> {
     eprintln!("finding leaked object paths-to-root");
     eprintln!("found {} likely leak candidates", leak_candidates.len());
 
-    let candidate_paths: Vec<Vec<_>> = find_paths(&edges, |f| leak_root_sources.contains(&f), &leak_candidates, 64)
+    let candidate_paths: Vec<Vec<_>> = find_paths(&edges, |f| leak_root_sources.contains(&f), &leak_candidates, 5)
         .iter()
         .map(|f| f.iter().map(|f| to_vec(f)).collect())
         .collect();
@@ -721,47 +721,97 @@ fn do_read_prof<'a, T: Id>(file: &'a [u8]) -> Result<()> {
         },
     )?;
 
-    for (paths, candidate) in izip!(candidate_paths.iter(), leak_candidates.iter()) {
-        println!("{candidate:x}");
+    // Group paths by class-name signature to deduplicate across all candidates.
+    // Many candidates may be held alive by the same code pattern (same class chain),
+    // differing only in which specific instances are involved.
+    let mut pattern_order: Vec<Vec<String>> = Vec::new();
+    let mut pattern_candidates: IntMap<Vec<String>, IntSet<T>> = IntMap::default();
+    let mut pattern_example: IntMap<Vec<String>, (T, Vec<(T, String)>)> = IntMap::default();
 
+    for (paths, &candidate) in izip!(candidate_paths.iter(), leak_candidates.iter()) {
         if paths.is_empty() {
-            println!("unk");
-            println!()
-        } else {
-            for path in paths {
-                for ele in path {
-                    println!(
-                        "{ele:x} {}",
-                        match inst_data.get(ele) {
-                            Some(HeapDumpEntry::InstanceDump(inst)) => {
-                                let class = classes.get(&inst.class_id).unwrap();
-                                let class_name_id = class_names.get(&class.id).unwrap();
-                                let dict = str_dict.borrow();
-                                let class_name = dict.get(class_name_id).unwrap();
-                                str::from_utf8(class_name)?.into()
-                            }
-                            Some(HeapDumpEntry::ObjArrayDump(inst)) => {
-                                let class = classes.get(&inst.class_id).unwrap();
-                                let class_name_id = class_names.get(&class.id).unwrap();
-                                let dict = str_dict.borrow();
-                                let class_name = dict.get(class_name_id).unwrap();
-                                format!("{}[]", str::from_utf8(class_name)?)
-                            }
-                            None => {
-                                let class = classes.get(ele).unwrap();
-                                let class_name_id = class_names.get(&class.id).unwrap();
-                                let dict = str_dict.borrow();
-                                let class_name = dict.get(class_name_id).unwrap();
-                                format!("Class<{}>", str::from_utf8(class_name)?)
-                            }
-                            _ => unreachable!(),
-                        }
-                    )
-                }
+            let sig = vec!["<no path found>".to_string()];
+            let is_new = !pattern_candidates.contains_key(&sig);
+            pattern_candidates.entry(sig.clone()).or_default().insert(candidate);
+            if is_new {
+                pattern_order.push(sig.clone());
+                pattern_example.insert(sig, (candidate, vec![]));
+            }
+            continue;
+        }
 
-                println!();
+        for path in paths {
+            let mut sig: Vec<String> = Vec::new();
+            let mut full_path: Vec<(T, String)> = Vec::new();
+
+            for ele in path {
+                let name: String = match inst_data.get(ele) {
+                    Some(HeapDumpEntry::InstanceDump(inst)) => {
+                        let class = classes.get(&inst.class_id).unwrap();
+                        let class_name_id = class_names.get(&class.id).unwrap();
+                        let dict = str_dict.borrow();
+                        let class_name = dict.get(class_name_id).unwrap();
+                        str::from_utf8(class_name)?.to_string()
+                    }
+                    Some(HeapDumpEntry::ObjArrayDump(inst)) => {
+                        let class = classes.get(&inst.class_id).unwrap();
+                        let class_name_id = class_names.get(&class.id).unwrap();
+                        let dict = str_dict.borrow();
+                        let class_name = dict.get(class_name_id).unwrap();
+                        format!("{}[]", str::from_utf8(class_name)?)
+                    }
+                    None => {
+                        let class = classes.get(ele).unwrap();
+                        let class_name_id = class_names.get(&class.id).unwrap();
+                        let dict = str_dict.borrow();
+                        let class_name = dict.get(class_name_id).unwrap();
+                        format!("Class<{}>", str::from_utf8(class_name)?)
+                    }
+                    _ => unreachable!(),
+                };
+                sig.push(name.clone());
+                full_path.push((*ele, name));
+            }
+
+            let is_new = !pattern_candidates.contains_key(&sig);
+            pattern_candidates.entry(sig.clone()).or_default().insert(candidate);
+            if is_new {
+                pattern_order.push(sig.clone());
+                pattern_example.insert(sig, (candidate, full_path));
             }
         }
+    }
+
+    // Most-common patterns first.
+    pattern_order.sort_by(|a, b| pattern_candidates[b].len().cmp(&pattern_candidates[a].len()));
+
+    println!(
+        "=== {} leaked WorldServer instance{}, {} unique retention pattern{} ===\n",
+        leak_candidates.len(),
+        if leak_candidates.len() == 1 { "" } else { "s" },
+        pattern_order.len(),
+        if pattern_order.len() == 1 { "" } else { "s" }
+    );
+
+    for (i, sig) in pattern_order.iter().enumerate() {
+        let candidates = &pattern_candidates[sig];
+        let (_example_candidate, example_path) = &pattern_example[sig];
+
+        println!(
+            "--- Pattern {} ({} instance{}) ---",
+            i + 1,
+            candidates.len(),
+            if candidates.len() == 1 { "" } else { "s" }
+        );
+
+        if example_path.is_empty() {
+            println!("  <no path found from scheduler to this WorldServer>");
+        } else {
+            for (id, name) in example_path {
+                println!("  {id:x} {name}");
+            }
+        }
+        println!();
     }
 
     Ok(())

--- a/rust/src/hprof/mod.rs
+++ b/rust/src/hprof/mod.rs
@@ -14,7 +14,7 @@ use smallvec::SmallVec;
 
 use crate::hprof::{
     graph::{IntMap, IntSet, clean_graph, find_shortest_path, is_reachable},
-    id::Id,
+    id::{Id, OopId},
 };
 
 mod graph;
@@ -492,7 +492,24 @@ fn visit_prof<
     mut on_gc_root: X,
     mut on_heap_entry: Y,
 ) -> Result<()> {
+    // Evict already-processed pages in 64 MiB chunks so the kernel can reclaim
+    // them while the rest of the pass is still running.
+    #[cfg(target_os = "linux")]
+    let mmap_start = file.as_ptr();
+    #[cfg(target_os = "linux")]
+    let mut next_dontneed_at: usize = 64 << 20;
+
     while !file.is_empty() {
+        #[cfg(target_os = "linux")]
+        {
+            let consumed = file.as_ptr() as usize - mmap_start as usize;
+            if consumed >= next_dontneed_at {
+                let evict_ptr = (mmap_start as usize + next_dontneed_at - (64 << 20)) as *mut libc::c_void;
+                unsafe { libc::madvise(evict_ptr, 64 << 20, libc::MADV_DONTNEED); }
+                next_dontneed_at += 64 << 20;
+            }
+        }
+
         let tag = file.read_u8()?;
         let _ = file.read_u32::<BigEndian>()?;
         let len: usize = file.read_u32::<BigEndian>()?.try_into()?;
@@ -966,12 +983,14 @@ pub fn read_prof(mut hprof_file: &[u8], min_leaked: usize) -> Result<bool> {
     let id_size = hprof_file.read_u32::<BigEndian>()?;
     let _micros = hprof_file.read_u64::<BigEndian>()?;
 
-    eprintln!("detected {id_size}-byte object IDs ({})", if id_size == 4 { "compressed OOPs" } else { "uncompressed OOPs" });
-
     if id_size == 4 {
+        eprintln!("detected 4-byte object IDs (compressed OOPs)");
         do_read_prof::<u32>(hprof_file, min_leaked)
     } else if id_size == 8 {
-        do_read_prof::<u64>(hprof_file, min_leaked)
+        // Shifted OOP values for heaps ≤ 32 GB fit in u32, halving edge memory.
+        // Fall back to u64 only if a value overflows (heap > 32 GB).
+        eprintln!("detected 8-byte object IDs (uncompressed OOPs); using compact u32 storage");
+        do_read_prof::<OopId>(hprof_file, min_leaked)
     } else {
         Err(anyhow!("illegal id_size: {id_size}"))
     }

--- a/rust/src/hprof/mod.rs
+++ b/rust/src/hprof/mod.rs
@@ -10,7 +10,7 @@ use phf::phf_map;
 use smallvec::SmallVec;
 
 use crate::hprof::{
-    graph::{IntMap, IntSet, clean_graph, find_paths, is_reachable, to_vec},
+    graph::{IntMap, IntSet, clean_graph, find_shortest_path, is_reachable},
     id::Id,
 };
 
@@ -694,9 +694,9 @@ fn do_read_prof<'a, T: Id>(file: &'a [u8], file_len_hint: usize) -> Result<()> {
     eprintln!("finding leaked object paths-to-root");
     eprintln!("found {} likely leak candidates", leak_candidates.len());
 
-    let candidate_paths: Vec<Vec<_>> = find_paths(&edges, |f| leak_root_sources.contains(&f), &leak_candidates, 5)
+    let candidate_paths: Vec<Vec<T>> = leak_candidates
         .iter()
-        .map(|f| f.iter().map(|f| to_vec(f)).collect())
+        .map(|&c| find_shortest_path(&edges, |f| leak_root_sources.contains(&f), c))
         .collect();
 
     eprintln!("re-gathering instance data");
@@ -705,7 +705,7 @@ fn do_read_prof<'a, T: Id>(file: &'a [u8], file_len_hint: usize) -> Result<()> {
 
     let mut relevant_inst: IntSet<T> = IntSet::default();
     let mut inst_data: IntMap<T, HeapDumpEntry<'a, T>> = IntMap::default();
-    relevant_inst.extend(candidate_paths.iter().flatten().flatten());
+    relevant_inst.extend(candidate_paths.iter().flatten().copied());
 
     let mut on_data = |id: T, data: HeapDumpEntry<'a, T>| {
         if relevant_inst.contains(&id) {
@@ -728,64 +728,62 @@ fn do_read_prof<'a, T: Id>(file: &'a [u8], file_len_hint: usize) -> Result<()> {
         },
     )?;
 
-    // Group paths by class-name signature to deduplicate across all candidates.
+    // Group shortest paths by class-name signature to deduplicate across all candidates.
     // Many candidates may be held alive by the same code pattern (same class chain),
     // differing only in which specific instances are involved.
     let mut pattern_order: Vec<Vec<String>> = Vec::new();
     let mut pattern_candidates: IntMap<Vec<String>, IntSet<T>> = IntMap::default();
-    let mut pattern_example: IntMap<Vec<String>, (T, Vec<(T, String)>)> = IntMap::default();
+    let mut pattern_example: IntMap<Vec<String>, Vec<(T, String)>> = IntMap::default();
 
-    for (paths, &candidate) in izip!(candidate_paths.iter(), leak_candidates.iter()) {
-        if paths.is_empty() {
+    for (path, &candidate) in izip!(candidate_paths.iter(), leak_candidates.iter()) {
+        if path.is_empty() {
             let sig = vec!["<no path found>".to_string()];
             let is_new = !pattern_candidates.contains_key(&sig);
             pattern_candidates.entry(sig.clone()).or_default().insert(candidate);
             if is_new {
                 pattern_order.push(sig.clone());
-                pattern_example.insert(sig, (candidate, vec![]));
+                pattern_example.insert(sig, vec![]);
             }
             continue;
         }
 
-        for path in paths {
-            let mut sig: Vec<String> = Vec::new();
-            let mut full_path: Vec<(T, String)> = Vec::new();
+        let mut sig: Vec<String> = Vec::new();
+        let mut full_path: Vec<(T, String)> = Vec::new();
 
-            for ele in path {
-                let name: String = match inst_data.get(ele) {
-                    Some(HeapDumpEntry::InstanceDump(inst)) => {
-                        let class = classes.get(&inst.class_id).unwrap();
-                        let class_name_id = class_names.get(&class.id).unwrap();
-                        let dict = str_dict.borrow();
-                        let class_name = dict.get(class_name_id).unwrap();
-                        str::from_utf8(class_name)?.to_string()
-                    }
-                    Some(HeapDumpEntry::ObjArrayDump(inst)) => {
-                        let class = classes.get(&inst.class_id).unwrap();
-                        let class_name_id = class_names.get(&class.id).unwrap();
-                        let dict = str_dict.borrow();
-                        let class_name = dict.get(class_name_id).unwrap();
-                        format!("{}[]", str::from_utf8(class_name)?)
-                    }
-                    None => {
-                        let class = classes.get(ele).unwrap();
-                        let class_name_id = class_names.get(&class.id).unwrap();
-                        let dict = str_dict.borrow();
-                        let class_name = dict.get(class_name_id).unwrap();
-                        format!("Class<{}>", str::from_utf8(class_name)?)
-                    }
-                    _ => unreachable!(),
-                };
-                sig.push(name.clone());
-                full_path.push((*ele, name));
-            }
+        for ele in path {
+            let name: String = match inst_data.get(ele) {
+                Some(HeapDumpEntry::InstanceDump(inst)) => {
+                    let class = classes.get(&inst.class_id).unwrap();
+                    let class_name_id = class_names.get(&class.id).unwrap();
+                    let dict = str_dict.borrow();
+                    let class_name = dict.get(class_name_id).unwrap();
+                    str::from_utf8(class_name)?.to_string()
+                }
+                Some(HeapDumpEntry::ObjArrayDump(inst)) => {
+                    let class = classes.get(&inst.class_id).unwrap();
+                    let class_name_id = class_names.get(&class.id).unwrap();
+                    let dict = str_dict.borrow();
+                    let class_name = dict.get(class_name_id).unwrap();
+                    format!("{}[]", str::from_utf8(class_name)?)
+                }
+                None => {
+                    let class = classes.get(ele).unwrap();
+                    let class_name_id = class_names.get(&class.id).unwrap();
+                    let dict = str_dict.borrow();
+                    let class_name = dict.get(class_name_id).unwrap();
+                    format!("Class<{}>", str::from_utf8(class_name)?)
+                }
+                _ => unreachable!(),
+            };
+            sig.push(name.clone());
+            full_path.push((*ele, name));
+        }
 
-            let is_new = !pattern_candidates.contains_key(&sig);
-            pattern_candidates.entry(sig.clone()).or_default().insert(candidate);
-            if is_new {
-                pattern_order.push(sig.clone());
-                pattern_example.insert(sig, (candidate, full_path));
-            }
+        let is_new = !pattern_candidates.contains_key(&sig);
+        pattern_candidates.entry(sig.clone()).or_default().insert(candidate);
+        if is_new {
+            pattern_order.push(sig.clone());
+            pattern_example.insert(sig, full_path);
         }
     }
 
@@ -802,7 +800,7 @@ fn do_read_prof<'a, T: Id>(file: &'a [u8], file_len_hint: usize) -> Result<()> {
 
     for (i, sig) in pattern_order.iter().enumerate() {
         let candidates = &pattern_candidates[sig];
-        let (_example_candidate, example_path) = &pattern_example[sig];
+        let example_path = &pattern_example[sig];
 
         println!(
             "--- Pattern {} ({} instance{}) ---",

--- a/rust/src/hprof/mod.rs
+++ b/rust/src/hprof/mod.rs
@@ -529,6 +529,16 @@ fn visit_prof<
     Ok(())
 }
 
+fn format_size(bytes: u64) -> String {
+    if bytes < 1024 {
+        format!("{bytes} B")
+    } else if bytes < 1024 * 1024 {
+        format!("{:.1} KB", bytes as f64 / 1024.0)
+    } else {
+        format!("{:.1} MB", bytes as f64 / (1024.0 * 1024.0))
+    }
+}
+
 fn do_read_prof<'a, T: Id>(file: &'a [u8]) -> Result<()> {
     use ClassNames::*;
 
@@ -549,12 +559,17 @@ fn do_read_prof<'a, T: Id>(file: &'a [u8]) -> Result<()> {
 
     let mut leak_root_sources = Vec::new();
 
-    let mut insert_edge = |child: T, parent: T| {
+    let mut edge_field_names: IntMap<(T, T), T> = IntMap::default();
+
+    let mut insert_edge = |child: T, parent: T, field_id: Option<T>| {
         if child == T::NULL {
             return;
         }
         // we want back refs, so child -> parent
         edges.push((child, parent));
+        if let Some(id) = field_id {
+            edge_field_names.entry((child, parent)).or_insert(id);
+        }
     };
 
     let get_class_id = |id: ClassNames| *class_ids[id as usize].get().unwrap();
@@ -588,16 +603,16 @@ fn do_read_prof<'a, T: Id>(file: &'a [u8]) -> Result<()> {
         |entry| {
             match entry {
                 HeapDumpEntry::ClassDump(class) => {
-                    for (_, static_value) in &class.statics {
+                    for (name_id, static_value) in &class.statics {
                         if let JVMValue::Obj(child) = static_value {
-                            insert_edge(*child, class.id);
+                            insert_edge(*child, class.id, Some(*name_id));
                         }
                     }
 
-                    insert_edge(class.super_id, class.id);
-                    insert_edge(class.class_loader_id, class.id);
-                    insert_edge(class.signers_id, class.id);
-                    insert_edge(class.protection_domain_id, class.id);
+                    insert_edge(class.super_id, class.id, None);
+                    insert_edge(class.class_loader_id, class.id, None);
+                    insert_edge(class.signers_id, class.id, None);
+                    insert_edge(class.protection_domain_id, class.id, None);
 
                     let res = classes.insert(class.id, class);
                     debug_assert!(res.is_none());
@@ -605,7 +620,7 @@ fn do_read_prof<'a, T: Id>(file: &'a [u8]) -> Result<()> {
                 HeapDumpEntry::InstanceDump(inst) => {
                     let class = classes.get(&inst.class_id).unwrap();
 
-                    insert_edge(class.id, inst.id);
+                    insert_edge(class.id, inst.id, None);
 
                     if inst.class_id == get_class_id(WorldServerClass) {
                         world_server_instances.push(inst.id);
@@ -638,14 +653,14 @@ fn do_read_prof<'a, T: Id>(file: &'a [u8]) -> Result<()> {
                         leak_root_sources.push(inst.id);
                     }
 
-                    class.iter_fields(inst.data, &classes, |cl_id, _, value| {
+                    class.iter_fields(inst.data, &classes, |cl_id, name_id, value| {
                         // ignore weak, phantom, etc
                         if cl_id == get_class_id(ReferenceClass) {
                             return;
                         }
 
                         if let JVMValue::Obj(child) = value {
-                            insert_edge(child, inst.id);
+                            insert_edge(child, inst.id, Some(name_id));
                         }
                     })?;
                 }
@@ -653,10 +668,10 @@ fn do_read_prof<'a, T: Id>(file: &'a [u8]) -> Result<()> {
                     let len = arr.data.len() / size_of::<T>();
                     let mut buf = arr.data;
 
-                    insert_edge(arr.class_id, arr.id);
+                    insert_edge(arr.class_id, arr.id, None);
 
                     for _ in 0..len {
-                        insert_edge(T::read_from(&mut buf)?, arr.id);
+                        insert_edge(T::read_from(&mut buf)?, arr.id, None);
                     }
                 }
                 _ => {}
@@ -716,6 +731,7 @@ fn do_read_prof<'a, T: Id>(file: &'a [u8]) -> Result<()> {
     let mut relevant_inst: IntSet<T> = IntSet::default();
     let mut inst_data: IntMap<T, HeapDumpEntry<'a, T>> = IntMap::default();
     relevant_inst.extend(all_paths.iter().flatten().flatten().copied());
+    relevant_inst.extend(all_candidates.iter().flatten().copied());
 
     let mut on_data = |id: T, data: HeapDumpEntry<'a, T>| {
         if relevant_inst.contains(&id) {
@@ -762,9 +778,11 @@ fn do_read_prof<'a, T: Id>(file: &'a [u8]) -> Result<()> {
                 continue;
             }
 
-            // Resolve class names for every element in the path.
+            // Resolve class names for every element in the path. Field annotations
+            // are collected separately so they don't affect signature matching.
             let mut raw: Vec<(T, String)> = Vec::new();
-            for ele in path {
+            let mut field_annotations: Vec<Option<String>> = Vec::new();
+            for (i, ele) in path.iter().enumerate() {
                 let name: String = match inst_data.get(ele) {
                     Some(HeapDumpEntry::InstanceDump(inst)) => {
                         let class = classes.get(&inst.class_id).unwrap();
@@ -789,7 +807,23 @@ fn do_read_prof<'a, T: Id>(file: &'a [u8]) -> Result<()> {
                     }
                     _ => unreachable!(),
                 };
+
+                // For element i > 0, look up which field of path[i] holds path[i-1].
+                let annotation = if i > 0 {
+                    let child = path[i - 1];
+                    edge_field_names.get(&(child, *ele)).map(|&field_id| {
+                        let dict = str_dict.borrow();
+                        dict.get(&field_id)
+                            .and_then(|b| str::from_utf8(b).ok())
+                            .unwrap_or("?")
+                            .to_string()
+                    })
+                } else {
+                    None
+                };
+
                 raw.push((*ele, name));
+                field_annotations.push(annotation);
             }
 
             // Signature: collapse consecutive same-class runs to one entry so paths
@@ -802,16 +836,23 @@ fn do_read_prof<'a, T: Id>(file: &'a [u8]) -> Result<()> {
                 }
             }
 
-            // Display path: same collapsing, but annotate runs with their count.
+            // Display path: same collapsing with run counts, plus field annotations
+            // from the first element of each run.
             let mut full_path: Vec<(T, String)> = Vec::new();
             let mut i = 0;
             while i < raw.len() {
                 let (ele, ref name) = raw[i];
+                let annotation = &field_annotations[i];
                 let mut run = 1;
                 while i + run < raw.len() && raw[i + run].1 == *name {
                     run += 1;
                 }
-                let display = if run > 1 { format!("{name} (×{run})") } else { name.clone() };
+                let base = if run > 1 { format!("{name} (×{run})") } else { name.clone() };
+                let display = if let Some(field) = annotation {
+                    format!("{base}  (.{field})")
+                } else {
+                    base
+                };
                 full_path.push((ele, display));
                 i += run;
             }
@@ -840,11 +881,23 @@ fn do_read_prof<'a, T: Id>(file: &'a [u8]) -> Result<()> {
             let matching = &pattern_candidates[sig];
             let example_path = &pattern_example[sig];
 
+            let total_bytes: u64 = matching
+                .iter()
+                .filter_map(|c| {
+                    if let Some(HeapDumpEntry::InstanceDump(inst)) = inst_data.get(c) {
+                        classes.get(&inst.class_id).map(|cl| cl.inst_size as u64)
+                    } else {
+                        None
+                    }
+                })
+                .sum();
+
             println!(
-                "--- Pattern {} ({} instance{}) ---",
+                "--- Pattern {} ({} instance{}, ~{} shallow) ---",
                 i + 1,
                 matching.len(),
-                if matching.len() == 1 { "" } else { "s" }
+                if matching.len() == 1 { "" } else { "s" },
+                format_size(total_bytes),
             );
 
             if example_path.is_empty() {

--- a/rust/src/hprof/mod.rs
+++ b/rust/src/hprof/mod.rs
@@ -747,9 +747,8 @@ fn do_read_prof<'a, T: Id>(file: &'a [u8], file_len_hint: usize) -> Result<()> {
             continue;
         }
 
-        let mut sig: Vec<String> = Vec::new();
-        let mut full_path: Vec<(T, String)> = Vec::new();
-
+        // Resolve class names for every element in the path.
+        let mut raw: Vec<(T, String)> = Vec::new();
         for ele in path {
             let name: String = match inst_data.get(ele) {
                 Some(HeapDumpEntry::InstanceDump(inst)) => {
@@ -775,8 +774,31 @@ fn do_read_prof<'a, T: Id>(file: &'a [u8], file_len_hint: usize) -> Result<()> {
                 }
                 _ => unreachable!(),
             };
-            sig.push(name.clone());
-            full_path.push((*ele, name));
+            raw.push((*ele, name));
+        }
+
+        // Signature: collapse consecutive same-class runs to one entry so paths
+        // that differ only in how many HashMap$Node / TreeNode hops the BFS
+        // traversed (varies by hash-bucket depth) map to the same pattern.
+        let mut sig: Vec<String> = Vec::new();
+        for (_, name) in &raw {
+            if sig.last().map_or(true, |last| last != name) {
+                sig.push(name.clone());
+            }
+        }
+
+        // Display path: same collapsing, but annotate runs with their count.
+        let mut full_path: Vec<(T, String)> = Vec::new();
+        let mut i = 0;
+        while i < raw.len() {
+            let (ele, ref name) = raw[i];
+            let mut run = 1;
+            while i + run < raw.len() && raw[i + run].1 == *name {
+                run += 1;
+            }
+            let display = if run > 1 { format!("{name} (×{run})") } else { name.clone() };
+            full_path.push((ele, display));
+            i += run;
         }
 
         let is_new = !pattern_candidates.contains_key(&sig);

--- a/rust/src/hprof/mod.rs
+++ b/rust/src/hprof/mod.rs
@@ -529,15 +529,6 @@ fn visit_prof<
     Ok(())
 }
 
-fn format_size(bytes: u64) -> String {
-    if bytes < 1024 {
-        format!("{bytes} B")
-    } else if bytes < 1024 * 1024 {
-        format!("{:.1} KB", bytes as f64 / 1024.0)
-    } else {
-        format!("{:.1} MB", bytes as f64 / (1024.0 * 1024.0))
-    }
-}
 
 fn do_read_prof<'a, T: Id>(file: &'a [u8], min_leaked: usize) -> Result<bool> {
     use ClassNames::*;
@@ -730,7 +721,6 @@ fn do_read_prof<'a, T: Id>(file: &'a [u8], min_leaked: usize) -> Result<bool> {
     let mut relevant_inst: IntSet<T> = IntSet::default();
     let mut inst_data: IntMap<T, HeapDumpEntry<'a, T>> = IntMap::default();
     relevant_inst.extend(candidate_paths.iter().flatten().copied());
-    relevant_inst.extend(candidates.iter().copied());
 
     let mut on_data = |id: T, data: HeapDumpEntry<'a, T>| {
         if relevant_inst.contains(&id) {
@@ -889,23 +879,11 @@ fn do_read_prof<'a, T: Id>(file: &'a [u8], min_leaked: usize) -> Result<bool> {
         let terminals = &pattern_terminals[sig];
         let example_path = &pattern_example[sig];
 
-        let total_bytes: u64 = terminals
-            .iter()
-            .filter_map(|c| {
-                if let Some(HeapDumpEntry::InstanceDump(inst)) = inst_data.get(c) {
-                    classes.get(&inst.class_id).map(|cl| cl.inst_size as u64)
-                } else {
-                    None
-                }
-            })
-            .sum();
-
         println!(
-            "--- Pattern {} ({} instance{}, ~{} shallow) ---",
+            "--- Pattern {} ({} instance{}) ---",
             i + 1,
             terminals.len(),
             if terminals.len() == 1 { "" } else { "s" },
-            format_size(total_bytes),
         );
 
         if example_path.is_empty() {

--- a/rust/src/hprof/mod.rs
+++ b/rust/src/hprof/mod.rs
@@ -558,7 +558,7 @@ fn madvise(file: &[u8], sequential: bool) {
     }
 }
 
-fn do_read_prof<'a, T: Id>(file: &'a [u8], min_leaked: usize, normalize_inner_classes: bool, show_ids: bool) -> Result<bool> {
+fn do_read_prof<'a, T: Id>(file: &'a [u8], min_leaked: usize, min_pattern_leaked: usize, normalize_inner_classes: bool, show_ids: bool) -> Result<bool> {
     use ClassNames::*;
 
     let str_dict = RefCell::new(IntMap::default());
@@ -825,6 +825,7 @@ fn do_read_prof<'a, T: Id>(file: &'a [u8], min_leaked: usize, normalize_inner_cl
     let mut pattern_order: Vec<Vec<String>> = Vec::new();
     let mut pattern_terminals: IntMap<Vec<String>, IntSet<T>> = IntMap::default();
     let mut pattern_example: IntMap<Vec<String>, Vec<(T, String)>> = IntMap::default();
+    let mut pattern_example_score: IntMap<Vec<String>, usize> = IntMap::default();
 
     for (path, &candidate) in izip!(candidate_paths.iter(), candidates.iter()) {
         if path.is_empty() {
@@ -934,10 +935,16 @@ fn do_read_prof<'a, T: Id>(file: &'a [u8], min_leaked: usize, normalize_inner_cl
             i += run;
         }
 
+        let annotation_score = field_annotations.iter().filter(|a| a.is_some()).count();
+
         let is_new = !pattern_terminals.contains_key(&sig);
         pattern_terminals.entry(sig.clone()).or_default().insert(terminal);
         if is_new {
             pattern_order.push(sig.clone());
+            pattern_example_score.insert(sig.clone(), annotation_score);
+            pattern_example.insert(sig, full_path);
+        } else if annotation_score > pattern_example_score[&sig] {
+            pattern_example_score.insert(sig.clone(), annotation_score);
             pattern_example.insert(sig, full_path);
         }
     }
@@ -945,24 +952,43 @@ fn do_read_prof<'a, T: Id>(file: &'a [u8], min_leaked: usize, normalize_inner_cl
     // Most-common patterns first.
     pattern_order.sort_by(|a, b| pattern_terminals[b].len().cmp(&pattern_terminals[a].len()));
 
+    let suppressed = pattern_order
+        .iter()
+        .filter(|sig| pattern_terminals[*sig].len() < min_pattern_leaked)
+        .count();
+    let suppressed_note = if suppressed > 0 {
+        format!(
+            " ({} suppressed by --min-pattern-leaked)",
+            suppressed
+        )
+    } else {
+        String::new()
+    };
+
     println!(
-        "=== {} leaked instance{}, {} unique retention pattern{} ===\n",
+        "=== {} leaked instance{}, {} unique retention pattern{}{} ===\n",
         candidates.len(),
         if candidates.len() == 1 { "" } else { "s" },
         pattern_order.len(),
-        if pattern_order.len() == 1 { "" } else { "s" }
+        if pattern_order.len() == 1 { "" } else { "s" },
+        suppressed_note,
     );
 
-    for (i, sig) in pattern_order.iter().enumerate() {
+    let mut display_index = 1usize;
+    for sig in pattern_order.iter() {
         let terminals = &pattern_terminals[sig];
+        if terminals.len() < min_pattern_leaked {
+            continue;
+        }
         let example_path = &pattern_example[sig];
 
         println!(
             "--- Pattern {} ({} instance{}) ---",
-            i + 1,
+            display_index,
             terminals.len(),
             if terminals.len() == 1 { "" } else { "s" },
         );
+        display_index += 1;
 
         if example_path.is_empty() {
             println!("  <no path found from scheduler>");
@@ -983,7 +1009,7 @@ fn do_read_prof<'a, T: Id>(file: &'a [u8], min_leaked: usize, normalize_inner_cl
 
 const HEADER: &[u8; 19] = b"JAVA PROFILE 1.0.2\0";
 
-pub fn read_prof(mut hprof_file: &[u8], min_leaked: usize, normalize_inner_classes: bool, show_ids: bool) -> Result<bool> {
+pub fn read_prof(mut hprof_file: &[u8], min_leaked: usize, min_pattern_leaked: usize, normalize_inner_classes: bool, show_ids: bool) -> Result<bool> {
     let mut header = [0; HEADER.len()];
     hprof_file.read_exact(&mut header)?;
 
@@ -996,12 +1022,12 @@ pub fn read_prof(mut hprof_file: &[u8], min_leaked: usize, normalize_inner_class
 
     if id_size == 4 {
         eprintln!("detected 4-byte object IDs (compressed OOPs)");
-        do_read_prof::<u32>(hprof_file, min_leaked, normalize_inner_classes, show_ids)
+        do_read_prof::<u32>(hprof_file, min_leaked, min_pattern_leaked, normalize_inner_classes, show_ids)
     } else if id_size == 8 {
         // Shifted OOP values for heaps ≤ 32 GB fit in u32, halving edge memory.
         // Fall back to u64 only if a value overflows (heap > 32 GB).
         eprintln!("detected 8-byte object IDs (uncompressed OOPs); using compact u32 storage");
-        do_read_prof::<OopId>(hprof_file, min_leaked, normalize_inner_classes, show_ids)
+        do_read_prof::<OopId>(hprof_file, min_leaked, min_pattern_leaked, normalize_inner_classes, show_ids)
     } else {
         Err(anyhow!("illegal id_size: {id_size}"))
     }

--- a/rust/src/hprof/mod.rs
+++ b/rust/src/hprof/mod.rs
@@ -3,6 +3,9 @@ use std::{
     io::{Error, Read},
 };
 
+#[cfg(target_os = "linux")]
+use libc;
+
 use anyhow::{Result, anyhow};
 use byteorder::{BigEndian, ReadBytesExt};
 use itertools::izip;
@@ -530,6 +533,14 @@ fn visit_prof<
 }
 
 
+fn madvise(file: &[u8], sequential: bool) {
+    #[cfg(target_os = "linux")]
+    unsafe {
+        let advice = if sequential { libc::MADV_SEQUENTIAL } else { libc::MADV_DONTNEED };
+        libc::madvise(file.as_ptr() as *mut libc::c_void, file.len(), advice);
+    }
+}
+
 fn do_read_prof<'a, T: Id>(file: &'a [u8], min_leaked: usize) -> Result<bool> {
     use ClassNames::*;
 
@@ -550,22 +561,19 @@ fn do_read_prof<'a, T: Id>(file: &'a [u8], min_leaked: usize) -> Result<bool> {
 
     let mut leak_root_sources = Vec::new();
 
-    let mut edge_field_names: IntMap<(T, T), T> = IntMap::default();
-
-    let mut insert_edge = |child: T, parent: T, field_id: Option<T>| {
+    let mut insert_edge = |child: T, parent: T| {
         if child == T::NULL {
             return;
         }
         // we want back refs, so child -> parent
         edges.push((child, parent));
-        if let Some(id) = field_id {
-            edge_field_names.entry((child, parent)).or_insert(id);
-        }
     };
 
     let get_class_id = |id: ClassNames| *class_ids[id as usize].get().unwrap();
 
     eprintln!("parsing heap dump");
+
+    madvise(file, true);
 
     visit_prof(
         file,
@@ -594,16 +602,16 @@ fn do_read_prof<'a, T: Id>(file: &'a [u8], min_leaked: usize) -> Result<bool> {
         |entry| {
             match entry {
                 HeapDumpEntry::ClassDump(class) => {
-                    for (name_id, static_value) in &class.statics {
+                    for (_name_id, static_value) in &class.statics {
                         if let JVMValue::Obj(child) = static_value {
-                            insert_edge(*child, class.id, Some(*name_id));
+                            insert_edge(*child, class.id);
                         }
                     }
 
-                    insert_edge(class.super_id, class.id, None);
-                    insert_edge(class.class_loader_id, class.id, None);
-                    insert_edge(class.signers_id, class.id, None);
-                    insert_edge(class.protection_domain_id, class.id, None);
+                    insert_edge(class.super_id, class.id);
+                    insert_edge(class.class_loader_id, class.id);
+                    insert_edge(class.signers_id, class.id);
+                    insert_edge(class.protection_domain_id, class.id);
 
                     let res = classes.insert(class.id, class);
                     debug_assert!(res.is_none());
@@ -611,7 +619,7 @@ fn do_read_prof<'a, T: Id>(file: &'a [u8], min_leaked: usize) -> Result<bool> {
                 HeapDumpEntry::InstanceDump(inst) => {
                     let class = classes.get(&inst.class_id).unwrap();
 
-                    insert_edge(class.id, inst.id, None);
+                    insert_edge(class.id, inst.id);
 
                     if inst.class_id == get_class_id(WorldServerClass) {
                         world_server_instances.push(inst.id);
@@ -644,14 +652,14 @@ fn do_read_prof<'a, T: Id>(file: &'a [u8], min_leaked: usize) -> Result<bool> {
                         leak_root_sources.push(inst.id);
                     }
 
-                    class.iter_fields(inst.data, &classes, |cl_id, name_id, value| {
+                    class.iter_fields(inst.data, &classes, |cl_id, _name_id, value| {
                         // ignore weak, phantom, etc
                         if cl_id == get_class_id(ReferenceClass) {
                             return;
                         }
 
                         if let JVMValue::Obj(child) = value {
-                            insert_edge(child, inst.id, Some(name_id));
+                            insert_edge(child, inst.id);
                         }
                     })?;
                 }
@@ -659,10 +667,10 @@ fn do_read_prof<'a, T: Id>(file: &'a [u8], min_leaked: usize) -> Result<bool> {
                     let len = arr.data.len() / size_of::<T>();
                     let mut buf = arr.data;
 
-                    insert_edge(arr.class_id, arr.id, None);
+                    insert_edge(arr.class_id, arr.id);
 
                     for _ in 0..len {
-                        insert_edge(T::read_from(&mut buf)?, arr.id, None);
+                        insert_edge(T::read_from(&mut buf)?, arr.id);
                     }
                 }
                 _ => {}
@@ -706,17 +714,51 @@ fn do_read_prof<'a, T: Id>(file: &'a [u8], min_leaked: usize) -> Result<bool> {
         }
     }
 
-    eprintln!("finding leaked instance paths-to-root");
     eprintln!("found {} likely leak candidates", candidates.len());
+
+    if candidates.len() < min_leaked {
+        return Ok(false);
+    }
+
+    eprintln!("finding leaked instance paths-to-root");
 
     let candidate_paths: Vec<Vec<T>> = candidates
         .iter()
         .map(|&c| find_shortest_path(&edges, |f| leak_root_sources.contains(&f), c))
         .collect();
 
+    // Build the small sets needed to collect field names in pass 2.
+    // Only edges that appear in candidate paths require a field name annotation.
+    let mut needed_field_edges: IntSet<(T, T)> = IntSet::default();
+    let mut needed_parent_set: IntSet<T> = IntSet::default();
+    for path in &candidate_paths {
+        for w in path.windows(2) {
+            needed_field_edges.insert((w[0], w[1]));
+            needed_parent_set.insert(w[1]);
+        }
+    }
+
+    // Class static field names can be resolved from the already-in-memory `classes` map.
+    let mut edge_field_names: IntMap<(T, T), T> = IntMap::default();
+    for (_, class) in &classes {
+        for (name_id, static_value) in &class.statics {
+            if let JVMValue::Obj(child) = static_value {
+                let edge = (*child, class.id);
+                if needed_field_edges.contains(&edge) {
+                    edge_field_names.entry(edge).or_insert(*name_id);
+                }
+            }
+        }
+    }
+
     eprintln!("re-gathering instance data");
 
     drop(edges);
+
+    // Release page cache for the mmap before re-reading so it doesn't compete
+    // with the in-memory data structures for RAM.
+    madvise(file, false);
+    madvise(file, true);
 
     let mut relevant_inst: IntSet<T> = IntSet::default();
     let mut inst_data: IntMap<T, HeapDumpEntry<'a, T>> = IntMap::default();
@@ -735,17 +777,29 @@ fn do_read_prof<'a, T: Id>(file: &'a [u8], min_leaked: usize) -> Result<bool> {
         |_| {},
         |inst| {
             match inst {
-                HeapDumpEntry::InstanceDump(inst) => on_data(inst.id, HeapDumpEntry::InstanceDump(inst)),
+                HeapDumpEntry::InstanceDump(inst) => {
+                    // While we have the instance data in hand, collect field names for
+                    // any candidate-path edges where this instance is the parent.
+                    if needed_parent_set.contains(&inst.id) {
+                        let class = classes.get(&inst.class_id).unwrap();
+                        class.iter_fields(inst.data, &classes, |cl_id, name_id, value| {
+                            if cl_id == get_class_id(ReferenceClass) { return; }
+                            if let JVMValue::Obj(child) = value {
+                                let edge = (child, inst.id);
+                                if needed_field_edges.contains(&edge) {
+                                    edge_field_names.entry(edge).or_insert(name_id);
+                                }
+                            }
+                        })?;
+                    }
+                    on_data(inst.id, HeapDumpEntry::InstanceDump(inst))
+                }
                 HeapDumpEntry::ObjArrayDump(inst) => on_data(inst.id, HeapDumpEntry::ObjArrayDump(inst)),
                 _ => {}
             }
             Ok(())
         },
     )?;
-
-    if candidates.len() < min_leaked {
-        return Ok(false);
-    }
 
     // Group paths by class-name signature, deduplicating across all candidate types.
     // Each path is trimmed to start at the last (nearest-to-scheduler) leak target
@@ -911,6 +965,8 @@ pub fn read_prof(mut hprof_file: &[u8], min_leaked: usize) -> Result<bool> {
 
     let id_size = hprof_file.read_u32::<BigEndian>()?;
     let _micros = hprof_file.read_u64::<BigEndian>()?;
+
+    eprintln!("detected {id_size}-byte object IDs ({})", if id_size == 4 { "compressed OOPs" } else { "uncompressed OOPs" });
 
     if id_size == 4 {
         do_read_prof::<u32>(hprof_file, min_leaked)


### PR DESCRIPTION
- Reduce memory usage
--- Compressed OOPs
--- Field names only populated in pass 2
--- Aggressively release memory during traversal
- Reduce CPU usage (faster hash algorithm)
- Significant changes to output format: 
--- BFS finds shortest paths
--- Paths are compacted together by default
- Added arguments to adjust output format. Default human-readable and aggressively compacted
- --json output format for machine readability / integration with exception logger
- Add CraftPlayer and EntityPlayer as potential leak results; terminate chain at first leakable object