### PR TITLE
Public SSH hardening

### DIFF
--- a/docker/basic-ssh.Dockerfile
+++ b/docker/basic-ssh.Dockerfile
@@ -1,7 +1,13 @@
+# This is the 'public' SSH dockerfile, which is heavily restricted.
+# Used for both play/build-ssh and play/mod-ssh
+# Only SFTP / file management is allowed
 FROM debian:stable
 
+# SFTP-only file server. Intentionally minimal: only openssh-server is installed
+# so there is nothing to execute, compile, or fetch with even if a shell were obtained.
 RUN apt-get update && \
-	apt-get install -y git tree ncdu curl wget openssh-server vim
+	apt-get install -y --no-install-recommends openssh-server && \
+	rm -rf /var/lib/apt/lists/*
 
 # Check for mandatory build arguments
 ARG USERNAME
@@ -14,31 +20,54 @@ RUN : "${GID:?'GID' argument needs to be set and non-empty.}"
 ENV USERHOME /home/$USERNAME
 
 RUN groupadd --non-unique -g $GID $USERNAME && \
-	# NOTE! -l flag prevents creation of gigabytes of sparse log file for some reason
-	useradd -lmNs /bin/bash -u $UID -g $GID $USERNAME && \
-	mkdir /var/run/sshd && \
+	# NOTE! -l flag prevents creation of gigabytes of sparse log file for some reason.
+	# nologin shell: forced internal-sftp means the shell is never invoked anyway.
+	# -p '*' sets a disabled (but NOT locked) password: pubkey auth is allowed,
+	# password auth is not. A locked '!' field makes sshd reject login under UsePAM no.
+	useradd -lmNs /usr/sbin/nologin -p '*' -u $UID -g $GID $USERNAME && \
+	# Drop the /etc/skel dotfiles copied in by useradd -m: the shell is never
+	# invoked (nologin + forced internal-sftp), so they are dead files at the chroot root.
+	rm -f $USERHOME/.bashrc $USERHOME/.bash_logout $USERHOME/.profile && \
+	mkdir -p /var/run/sshd && \
+	# Generate host keys at build time: the runtime root filesystem is read-only,
+	# so keys cannot be generated on first boot.
+	ssh-keygen -A && \
 	mkdir $USERHOME/.ssh && \
 	echo "\
 Port 22                                                \n\
 PermitRootLogin no                                     \n\
 PasswordAuthentication no                              \n\
-ChallengeResponseAuthentication no                     \n\
-UsePAM yes                                             \n\
-AllowAgentForwarding yes                               \n\
+KbdInteractiveAuthentication no                        \n\
+UsePAM no                                              \n\
+UseDNS no                                              \n\
+AllowAgentForwarding no                                \n\
 AllowTcpForwarding no                                  \n\
 GatewayPorts no                                        \n\
 X11Forwarding no                                       \n\
 PrintMotd no                                           \n\
 TCPKeepAlive yes                                       \n\
 PermitTunnel no                                        \n\
+PidFile /run/sshd.pid                                  \n\
 AcceptEnv LANG LC_*                                    \n\
-Subsystem       sftp    /usr/lib/openssh/sftp-server   \n\
-AllowUsers $USERNAME" > /etc/ssh/sshd_config
+Subsystem       sftp    internal-sftp                  \n\
+AllowUsers $USERNAME                                   \n\
+Match User $USERNAME                                   \n\
+\tChrootDirectory $USERHOME                            \n\
+\tForceCommand internal-sftp                           \n\
+\tPermitTTY no" > /etc/ssh/sshd_config
 
-RUN chown -R $USERNAME:$USERNAME $USERHOME/.ssh && \
-	chmod go-rwx $USERHOME/.ssh
+# ChrootDirectory and every parent must be owned by root and not group/world
+# writable. Note: chown is non-recursive, so .ssh keeps the ownership set below.
+RUN chown root:root $USERHOME && \
+	chmod 755 $USERHOME && \
+	# .ssh must be owned/traversable by the login user: sshd reads authorized_keys
+	# as that user (before chroot), so a root-owned 0700 .ssh would block it.
+	chown $USERNAME:$USERNAME $USERHOME/.ssh && \
+	chmod 700 $USERHOME/.ssh
 
 EXPOSE 22
 
 USER root
-CMD ["/usr/sbin/sshd", "-D"]
+# Prepare the privilege-separation dir + pidfile location on the writable /run
+# tmpfs (the root filesystem is read-only at runtime), then exec sshd.
+CMD ["/bin/sh", "-c", "mkdir -p /run/sshd && chmod 0755 /run/sshd && exec /usr/sbin/sshd -D -e"]

--- a/docker/k8s/init-cluster/cilium-global-firewall.yaml
+++ b/docker/k8s/init-cluster/cilium-global-firewall.yaml
@@ -35,7 +35,11 @@ spec:
               protocol: TCP
             - port: "9922"    # Admin lxc SSH
               protocol: TCP
-            - port: "8822"    # Build SSH container
+            - port: "8822"    # Build SSH container (docker/k8s/build/basic-ssh.yml)
+              protocol: TCP
+            - port: "6622"    # Play build-ssh SFTP (docker/k8s/play/build-ssh.yml)
+              protocol: TCP
+            - port: "10022"   # Play mod-ssh SFTP (docker/k8s/play/mod-ssh.yml)
               protocol: TCP
             - port: "7722"    # Root SSH
               protocol: TCP

--- a/docker/k8s/play/build-ssh.yml
+++ b/docker/k8s/play/build-ssh.yml
@@ -17,6 +17,7 @@ spec:
       labels:
         app: build-ssh
     spec:
+      automountServiceAccountToken: false
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -27,6 +28,10 @@ spec:
                 values:
                 - monumenta-17
       volumes:
+        - name: run
+          emptyDir:
+            medium: Memory
+            sizeLimit: 16Mi
         - name: scriptedquests
           hostPath:
             type: Directory
@@ -39,6 +44,9 @@ spec:
           hostPath:
             type: Directory
             path: /nfs/play/m17/build/logs
+        # Empty overlay used to shadow logs/chat so its contents are not exposed over SFTP.
+        - name: hide-logs-chat
+          emptyDir: {}
         - name: authorized-keys-config
           secret:
             secretName: authorized-keys-config
@@ -49,11 +57,30 @@ spec:
         imagePullPolicy: Always
         tty: false
         stdin: false
+        securityContext:
+          runAsUser: 0                # sshd master must start as root for chroot + privsep
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          seccompProfile:
+            type: RuntimeDefault
+          capabilities:
+            drop: ["ALL"]
+            # NET_BIND_SERVICE: bind :22; SETUID/SETGID: per-session privsep; SYS_CHROOT: ChrootDirectory
+            add: ["NET_BIND_SERVICE", "SETUID", "SETGID", "SYS_CHROOT"]
+        resources:
+          requests:
+            cpu: "50m"
+            memory: "64Mi"
+          limits:
+            cpu: "500m"
+            memory: "256Mi"
         ports:
         - containerPort: 22
           hostPort: 6622
           hostIP: "15.235.84.119" # The node's external facing IP address
         volumeMounts:
+        - name: run
+          mountPath: /run
         - name: scriptedquests
           mountPath: /home/epic/scriptedquests
         - name: datapacks
@@ -61,8 +88,40 @@ spec:
         - name: logs
           mountPath: /home/epic/logs
           readOnly: true
+        # Mounted after (deeper than) logs, so it shadows the real logs/chat with an empty dir.
+        - name: hide-logs-chat
+          mountPath: /home/epic/logs/chat
+          readOnly: true
         - name: authorized-keys-config
           mountPath: /home/epic/.ssh/authorized_keys
           subPath: authorized_keys
       imagePullSecrets:
       - name: githubcred
+---
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: "build-ssh-firewall"
+  namespace: play
+spec:
+  description: "SFTP file server: inbound SSH only, no egress"
+  endpointSelector:
+    matchLabels:
+      app: build-ssh
+  enableDefaultDeny:
+    # Deny all egress even though no egress allow-rules are listed: the pod
+    # serves files inbound only and must not initiate outbound connections.
+    egress: true
+    ingress: true
+  ingress:
+    # hostPort DNAT arrives with the 'host' identity
+    - fromEntities:
+        - host
+    # Direct pod-IP access from outside the cluster
+    - fromEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "22"
+              protocol: TCP
+  # No egress rules => with enableDefaultDeny.egress all outbound traffic is dropped.

--- a/docker/k8s/play/mod-ssh.yml
+++ b/docker/k8s/play/mod-ssh.yml
@@ -17,6 +17,7 @@ spec:
       labels:
         app: mod-ssh
     spec:
+      automountServiceAccountToken: false
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -27,6 +28,10 @@ spec:
                 values:
                 - monumenta-17
       volumes:
+        - name: run
+          emptyDir:
+            medium: Memory
+            sizeLimit: 16Mi
         - name: chat-global-filters
           hostPath:
             type: Directory
@@ -53,11 +58,30 @@ spec:
         imagePullPolicy: Always
         tty: false
         stdin: false
+        securityContext:
+          runAsUser: 0                # sshd master must start as root for chroot + privsep
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          seccompProfile:
+            type: RuntimeDefault
+          capabilities:
+            drop: ["ALL"]
+            # NET_BIND_SERVICE: bind :22; SETUID/SETGID: per-session privsep; SYS_CHROOT: ChrootDirectory
+            add: ["NET_BIND_SERVICE", "SETUID", "SETGID", "SYS_CHROOT"]
+        resources:
+          requests:
+            cpu: "50m"
+            memory: "64Mi"
+          limits:
+            cpu: "500m"
+            memory: "256Mi"
         ports:
         - containerPort: 22
           hostPort: 10022
           hostIP: "15.235.84.119" # The node's external facing IP address
         volumeMounts:
+        - name: run
+          mountPath: /run
         - name: chat-global-filters
           mountPath: /home/epic/global_chat_filters
         - name: chat-help-m17
@@ -70,3 +94,31 @@ spec:
         - name: authorized-keys-config
           mountPath: /home/epic/.ssh/authorized_keys
           subPath: authorized_keys
+---
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: "mod-ssh-firewall"
+  namespace: play
+spec:
+  description: "SFTP file server: inbound SSH only, no egress"
+  endpointSelector:
+    matchLabels:
+      app: mod-ssh
+  enableDefaultDeny:
+    # Deny all egress even though no egress allow-rules are listed: the pod
+    # serves files inbound only and must not initiate outbound connections.
+    egress: true
+    ingress: true
+  ingress:
+    # hostPort DNAT arrives with the 'host' identity
+    - fromEntities:
+        - host
+    # Direct pod-IP access from outside the cluster
+    - fromEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "22"
+              protocol: TCP
+  # No egress rules => with enableDefaultDeny.egress all outbound traffic is dropped.


### PR DESCRIPTION
build shard/mod SSH containers now
- Only allow SFTP, no console access
- Run in chroot
- Containers drop unnecessary privileges
- Run with readonly rootfs
- Have an explicit Cilium firewall that blocks all egress traffic
- Have CPU/memory limits

Build SSH now mounts an empty dir over logs/chat